### PR TITLE
added some todos

### DIFF
--- a/esp_data_temp/config.py
+++ b/esp_data_temp/config.py
@@ -8,8 +8,11 @@ from .transformations import TransformCfg
 
 class DataConfig(BaseModel):
     dataset_name: str
-    label_column: str
-    label_type: Literal["supervised", "self-supervised"]
+
+    # TODO (milad) do we need these?
+    # label_column: str
+    # label_type: Literal["supervised", "self-supervised"]
+
     transformations: Optional[List[TransformCfg]] = None  # <- changed
     # TODO (milad) what is dc_field? 🤔
     read_csv_kwargs: Dict[str, Any] = dc_field(default_factory=dict)

--- a/esp_data_temp/dataset.py
+++ b/esp_data_temp/dataset.py
@@ -73,6 +73,8 @@ class AudioDataset:
     def __len__(self) -> int:
         return len(self.metadata)
 
+    # TODO (milad) we mostly care about iteration so define __iter__
+
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         row = self.metadata.iloc[idx]
         path_str: str = row[self.audio_path_col]


### PR DESCRIPTION
- [ ] Do we want to have a unified return format? We currently have the following fields:
  - `raw_wav`
  - `text_label`
  - `label`
  - `path`
  
  but maybe that's too restricting? Maybe we want to allow the user to define the format in the config? 