### PR TITLE
add cross-set retrieval

### DIFF
--- a/configs/data_configs/benchmark_id_repertoire_with_clustering.yml
+++ b/configs/data_configs/benchmark_id_repertoire_with_clustering.yml
@@ -104,6 +104,41 @@ evaluation_sets:
           label_map: {212: 0, 312: 1, 712: 2, 811: 3, 911: 4, 1011: 5, 1211: 6, 1511: 7, 1611: 8, 1711: 9}
 
     metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "train_vs_test"
+
+  - name: "pipit_id_across_year_test_vs_test"
+    train:
+      dataset_name: "pipit_id"
+      split: "train_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {212: 0, 312: 1, 712: 2, 811: 3, 911: 4, 1011: 5, 1211: 6, 1511: 7, 1611: 8, 1711: 9}
+
+    validation:
+      dataset_name: "pipit_id"
+      split: "train_across_year"  # Use same as train
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {212: 0, 312: 1, 712: 2, 811: 3, 911: 4, 1011: 5, 1211: 6, 1511: 7, 1611: 8, 1711: 9}
+
+    test:
+      dataset_name: "pipit_id"
+      split: "test_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {212: 0, 312: 1, 712: 2, 811: 3, 911: 4, 1011: 5, 1211: 6, 1511: 7, 1611: 8, 1711: 9}
+
+    metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "test_vs_test"
 
   - name: "chiffchaff_id_within_year"
     train:
@@ -170,6 +205,41 @@ evaluation_sets:
           label_map: {'F72726': 0, 'F91903': 1, 'F91907': 2, 'F91913': 3, 'F91915': 4, 'F91916': 5, 'F91954': 6, 'F91959': 7, 'F91969': 8, 'F91973': 9}
 
     metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "train_vs_test"
+
+  - name: "chiffchaff_id_across_year_test_vs_test"
+    train:
+      dataset_name: "chiffchaff_id"
+      split: "train_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'F72726': 0, 'F91903': 1, 'F91907': 2, 'F91913': 3, 'F91915': 4, 'F91916': 5, 'F91954': 6, 'F91959': 7, 'F91969': 8, 'F91973': 9}
+
+    validation:
+      dataset_name: "chiffchaff_id"
+      split: "train_across_year"  # Use same as train
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'F72726': 0, 'F91903': 1, 'F91907': 2, 'F91913': 3, 'F91915': 4, 'F91916': 5, 'F91954': 6, 'F91959': 7, 'F91969': 8, 'F91973': 9}
+
+    test:
+      dataset_name: "chiffchaff_id"
+      split: "test_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'F72726': 0, 'F91903': 1, 'F91907': 2, 'F91913': 3, 'F91915': 4, 'F91916': 5, 'F91954': 6, 'F91959': 7, 'F91969': 8, 'F91973': 9}
+
+    metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "test_vs_test"
 
   - name: "littleowl_id_across_year"
     train:
@@ -203,6 +273,41 @@ evaluation_sets:
           label_map: {'108': 0, '193': 1, '229': 2, '7': 3, '94': 4, 'BRE': 5, 'CER': 6, 'DUB': 7, 'KME': 8, 'LIS': 9, 'MNE': 10, 'PAL': 11, 'RAC': 12, 'RADBF': 13, 'RADK': 14, 'VEV': 15}
 
     metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "train_vs_test"
+
+  - name: "littleowl_id_across_year_test_vs_test"
+    train:
+      dataset_name: "littleowl_id"
+      split: "train_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'108': 0, '193': 1, '229': 2, '7': 3, '94': 4, 'BRE': 5, 'CER': 6, 'DUB': 7, 'KME': 8, 'LIS': 9, 'MNE': 10, 'PAL': 11, 'RAC': 12, 'RADBF': 13, 'RADK': 14, 'VEV': 15}
+
+    validation:
+      dataset_name: "littleowl_id"
+      split: "train_across_year"  # Use same as train
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'108': 0, '193': 1, '229': 2, '7': 3, '94': 4, 'BRE': 5, 'CER': 6, 'DUB': 7, 'KME': 8, 'LIS': 9, 'MNE': 10, 'PAL': 11, 'RAC': 12, 'RADBF': 13, 'RADK': 14, 'VEV': 15}
+
+    test:
+      dataset_name: "littleowl_id"
+      split: "test_across_year"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "individual_id"
+          override: true
+          label_map: {'108': 0, '193': 1, '229': 2, '7': 3, '94': 4, 'BRE': 5, 'CER': 6, 'DUB': 7, 'KME': 8, 'LIS': 9, 'MNE': 10, 'PAL': 11, 'RAC': 12, 'RADBF': 13, 'RADK': 14, 'VEV': 15}
+
+    metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+    retrieval_mode: "test_vs_test"
 
   # - name: "giant_otters_individual_id"
   #   train:
@@ -327,3 +432,69 @@ evaluation_sets:
           label_map: {'Bark': 0, 'Bark-like vocalization': 1, 'Begging Scream': 2, 'Begging call': 3, 'Begging call-like vocalization': 4, 'Begging scream gradat': 5, 'Close Call': 6, 'Contact Call': 7, 'Contact call gradation': 8, 'Contact call-like vocalization': 9, 'Distress call 1': 10, 'Distress call 2': 11, 'Growl': 12, 'Hah!': 13, 'High whistle': 14, 'Hum': 15, 'Hum gradation': 16, 'Hum gradation-like vocalization': 17, 'Hum short': 18, 'Hum-like vocalization': 19, 'Isolation Call': 20, 'Low whistle': 21, 'Scream Ascending': 22, 'Snort': 23, 'Suckling Call': 24, 'Suckling call': 25, 'Wavering Scream': 26, 'Whine': 27, 'Whistle': 28, 'Whistle Double': 29, 'under water call': 30, 'whine': 31}
 
     metrics: ["accuracy", "multiclass_f1", "clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+
+  - name: "bengalese_finch_repertoire_bird0"
+    train:  # Dummy train set (using test set for compatibility)
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird0"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8}
+
+    validation:  # Dummy validation set (using test set for compatibility)
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird0"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8}
+
+    test:
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird0"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8}
+
+    metrics: ["clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]
+
+  - name: "bengalese_finch_repertoire_bird1"
+    train:  # Dummy train set (using test set for compatibility)
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird1"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9, 'a': 10, 'c': 11}
+
+    validation:  # Dummy validation set (using test set for compatibility)
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird1"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9, 'a': 10, 'c': 11}
+
+    test:
+      dataset_name: "Bengalese Finch Calls"
+      split: "Bird1"
+      sample_rate: 16000
+      transformations:
+        - type: "label_from_feature"
+          feature: "call_type"
+          override: true
+          label_map: {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9, 'a': 10, 'c': 11}
+
+    metrics: ["clustering_ari", "clustering_nmi", "clustering_v_measure", "clustering_silhouette"]

--- a/configs/evaluation_configs/single_model/efficientnet_beans.yml
+++ b/configs/evaluation_configs/single_model/efficientnet_beans.yml
@@ -18,7 +18,7 @@ experiments:
     layers: model.avgpool
     ### whether to use pretrained model or the one we train on bioacoustic data
     pretrained: false
-    checkpoint_path: runs/efficientnet_single_15_05/checkpoints/checkpoint_epoch_029.pt
+    checkpoint_path: ../representation-learning/runs/efficientnet_single_15_05/checkpoints/checkpoint_epoch_029.pt
 
 # Where to save the evaluation results
 save_dir: evaluation_results/efficientnet_beans

--- a/representation_learning/configs.py
+++ b/representation_learning/configs.py
@@ -607,6 +607,15 @@ class EvaluationSet(BaseModel):
         description="List of metrics to compute for this evaluation set",
     )
 
+    # Add retrieval mode configuration
+    retrieval_mode: Literal["test_vs_test", "train_vs_test"] = Field(
+        "test_vs_test",
+        description=(
+            "Retrieval evaluation mode: 'test_vs_test' (current default) "
+            "or 'train_vs_test'"
+        ),
+    )
+
     model_config = ConfigDict(extra="forbid")
 
     def to_dataset_collection_config(self) -> DatasetCollectionConfig:

--- a/representation_learning/data/dataset.py
+++ b/representation_learning/data/dataset.py
@@ -165,6 +165,11 @@ def _build_datasets(
     if cfg.transformations:
         # Apply those on train and update metadata
         train_metadata = train_ds.apply_transformations(cfg.transformations)
+        additional_metadata = train_ds.apply_transformations(cfg.transformations)
+        if additional_metadata:
+            # Merge the additional metadata with existing metadata
+            train_metadata = train_metadata or {}
+            train_metadata.update(additional_metadata)
 
     # Build validation
     val_ds, _ = _build_one_dataset_split(

--- a/representation_learning/utils/utils.py
+++ b/representation_learning/utils/utils.py
@@ -1,8 +1,7 @@
 """
 General utility functions for the representation learning package.
 
-This module contains utility functions that are used across multiple modules,
-including universal file loading functionality.
+This module contains utility functions that are used across multiple modules.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Adding a new variant of evaluation by retrieval. Rather than evaluating within the test-set, evaluating between two splits.
This is particularly important for "cross-year" individual-ID splits, or generally if we want to evaluate a search-by-audio case with separated query and database sets.
This also makes use of the new Bengalese Finch datasets added in esp-data. We might tweak the setup of these down the line, for now using only the first two birds and planning to only consider retrieval and clustering.