### PR TITLE
Add OpenBEATs

### DIFF
--- a/configs/evaluation_configs/single_models_beans/openbeats_base_i2.yml
+++ b/configs/evaluation_configs/single_models_beans/openbeats_base_i2.yml
@@ -1,0 +1,42 @@
+---
+# Evaluation config for OpenBEATs Base (i2) pretrained checkpoint
+dataset_config: configs/data_configs/benchmark_base.yml
+
+training_params:
+  train_epochs: 50
+  lr: 0.001
+  batch_size: 128
+  optimizer: adamw
+  weight_decay: 0.01
+  amp: false
+  amp_dtype: bf16
+  gradient_clip_val: 1.0
+  warmup_epochs: 5
+  scheduler_type: cosine
+
+experiments:
+  - run_name: openbeats_base_i2_linear_last
+    run_config: configs/run_configs/pretrained/openbeats_base_i2.yml
+    probe_config:
+      probe_type: "linear"
+      aggregation: "mean"
+      input_processing: "pooled"
+      target_layers: ["last_layer"]
+      freeze_backbone: true
+      online_training: false
+    pretrained: false
+
+save_dir: evaluation_results/openbeats_base_i2
+results_csv_path: evaluation_results/all_models_results.csv
+
+device: cuda
+seed: 42
+num_workers: 8
+
+eval_modes:
+  - probe
+
+offline_embeddings:
+  overwrite_embeddings: true
+
+disable_tqdm: true

--- a/configs/evaluation_configs/single_models_beans/openbeats_base_i2.yml
+++ b/configs/evaluation_configs/single_models_beans/openbeats_base_i2.yml
@@ -16,7 +16,7 @@ training_params:
 
 experiments:
   - run_name: openbeats_base_i2_linear_last
-    run_config: configs/run_configs/pretrained/openbeats_base_i2.yml
+    run_config: configs/run_configs/aaai_train/sl_openbeats_base_animalspeak_audioset.yml
     probe_config:
       probe_type: "linear"
       aggregation: "mean"

--- a/configs/evaluation_configs/single_models_beans/openbeats_large_i2.yml
+++ b/configs/evaluation_configs/single_models_beans/openbeats_large_i2.yml
@@ -1,0 +1,42 @@
+---
+# Evaluation config for OpenBEATs Large (i2) pretrained checkpoint
+dataset_config: configs/data_configs/benchmark_base.yml
+
+training_params:
+  train_epochs: 50
+  lr: 0.001
+  batch_size: 128
+  optimizer: adamw
+  weight_decay: 0.01
+  amp: false
+  amp_dtype: bf16
+  gradient_clip_val: 1.0
+  warmup_epochs: 5
+  scheduler_type: cosine
+
+experiments:
+  - run_name: openbeats_large_i2_linear_last
+    run_config: configs/run_configs/pretrained/openbeats_large_i2.yml
+    probe_config:
+      probe_type: "linear"
+      aggregation: "mean"
+      input_processing: "pooled"
+      target_layers: ["last_layer"]
+      freeze_backbone: true
+      online_training: false
+    pretrained: false
+
+save_dir: evaluation_results/openbeats_large_i2
+results_csv_path: evaluation_results/all_models_results.csv
+
+device: cuda
+seed: 42
+num_workers: 8
+
+eval_modes:
+  - probe
+
+offline_embeddings:
+  overwrite_embeddings: true
+
+disable_tqdm: true

--- a/configs/evaluation_configs/single_models_beans/openbeats_large_i2.yml
+++ b/configs/evaluation_configs/single_models_beans/openbeats_large_i2.yml
@@ -16,7 +16,7 @@ training_params:
 
 experiments:
   - run_name: openbeats_large_i2_linear_last
-    run_config: configs/run_configs/pretrained/openbeats_large_i2.yml
+    run_config: configs/run_configs/aaai_train/sl_openbeats_large_animalspeak_audioset.yml
     probe_config:
       probe_type: "linear"
       aggregation: "mean"

--- a/configs/run_configs/aaai_train/sl_openbeats_base_animalspeak_audioset.yml
+++ b/configs/run_configs/aaai_train/sl_openbeats_base_animalspeak_audioset.yml
@@ -23,7 +23,6 @@ preprocessing: null
 sr: 16000
 debug_mode: false
 logging: wandb
-log_checkpoints_to_wandb: true
 resume_from_checkpoint: null
 
 training_params:

--- a/configs/run_configs/aaai_train/sl_openbeats_base_animalspeak_audioset.yml
+++ b/configs/run_configs/aaai_train/sl_openbeats_base_animalspeak_audioset.yml
@@ -1,0 +1,68 @@
+---
+# OpenBEATs Base (i2) fine-tuning on AnimalSpeak + AudioSet labels (multilabel)
+model_spec:
+  name: beats
+  pretrained: true
+  beats_variant: openbeats
+  openbeats_size: base
+  device: cuda
+  audio_config:  # BEATs/OpenBEATs expect raw waveform
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+
+dataset_config: configs/data_configs/aaai_train/data_animalspeak_audioset.yml
+
+output_dir: "./runs/aaai/sl_openbeats_base_animalspeak_audioset"
+multilabel: true
+label_type: supervised
+run_name: sl_openbeats_base_animalspeak_audioset
+preprocessing: null
+sr: 16000
+debug_mode: false
+logging: wandb
+log_checkpoints_to_wandb: true
+resume_from_checkpoint: null
+
+training_params:
+  train_epochs: 10
+  lr: 0.0003
+  batch_size: 64
+  optimizer: adamw8bit
+  weight_decay: 0.01
+  amp: true
+  amp_dtype: bf16
+
+scheduler:
+  name: cosine
+  warmup_steps: 4000
+  min_lr: 1e-6
+
+augmentations:
+  - noise:
+      noise_dirs:
+        - "/scratch-representation-learning/noise_16k/demand_10s"
+        - "/scratch-representation-learning/noise_16k/idmt"
+        - "/scratch-representation-learning/noise_16k/tut2016_10s"
+        - "/scratch-representation-learning/noise_16k/urbansound"
+        - "/scratch-representation-learning/noise_16k/freesound_10s"
+        - "/scratch-representation-learning/noise_16k/orcasound_shipnoise_10s"
+        - "/scratch-representation-learning/noise_16k/deepship_10s"
+        - "/scratch-representation-learning/noise_16k/shipsear_10s"
+        - "/scratch-representation-learning/noise_16k/wham_noise"
+        - "/scratch-representation-learning/noise_16k/audioset"
+      snr_db_range: [-5, 20]
+      augmentation_prob: 0.5
+  - mixup:
+      alpha: 0.4
+      n_mixup: 1
+      augmentation_prob: 0.5
+
+loss_function: bce
+
+seed: 13
+num_workers: 12
+
+wandb_project: representation_learning

--- a/configs/run_configs/aaai_train/sl_openbeats_large_animalspeak_audioset.yml
+++ b/configs/run_configs/aaai_train/sl_openbeats_large_animalspeak_audioset.yml
@@ -1,0 +1,68 @@
+---
+# OpenBEATs Large (i2) fine-tuning on AnimalSpeak + AudioSet labels (multilabel)
+model_spec:
+  name: beats
+  pretrained: true
+  beats_variant: openbeats
+  openbeats_size: large
+  device: cuda
+  audio_config:  # BEATs/OpenBEATs expect raw waveform
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+
+dataset_config: configs/data_configs/aaai_train/data_animalspeak_audioset.yml
+
+output_dir: "./runs/aaai/sl_openbeats_large_animalspeak_audioset"
+multilabel: true
+label_type: supervised
+run_name: sl_openbeats_large_animalspeak_audioset
+preprocessing: null
+sr: 16000
+debug_mode: false
+logging: wandb
+log_checkpoints_to_wandb: true
+resume_from_checkpoint: null
+
+training_params:
+  train_epochs: 10
+  lr: 0.0002
+  batch_size: 16
+  optimizer: adamw8bit
+  weight_decay: 0.01
+  amp: true
+  amp_dtype: bf16
+
+scheduler:
+  name: cosine
+  warmup_steps: 4000
+  min_lr: 1e-6
+
+augmentations:
+  - noise:
+      noise_dirs:
+        - "/scratch-representation-learning/noise_16k/demand_10s"
+        - "/scratch-representation-learning/noise_16k/idmt"
+        - "/scratch-representation-learning/noise_16k/tut2016_10s"
+        - "/scratch-representation-learning/noise_16k/urbansound"
+        - "/scratch-representation-learning/noise_16k/freesound_10s"
+        - "/scratch-representation-learning/noise_16k/orcasound_shipnoise_10s"
+        - "/scratch-representation-learning/noise_16k/deepship_10s"
+        - "/scratch-representation-learning/noise_16k/shipsear_10s"
+        - "/scratch-representation-learning/noise_16k/wham_noise"
+        - "/scratch-representation-learning/noise_16k/audioset"
+      snr_db_range: [-5, 20]
+      augmentation_prob: 0.5
+  - mixup:
+      alpha: 0.4
+      n_mixup: 1
+      augmentation_prob: 0.5
+
+loss_function: bce
+
+seed: 13
+num_workers: 12
+
+wandb_project: representation_learning

--- a/configs/run_configs/aaai_train/sl_openbeats_large_animalspeak_audioset.yml
+++ b/configs/run_configs/aaai_train/sl_openbeats_large_animalspeak_audioset.yml
@@ -23,7 +23,6 @@ preprocessing: null
 sr: 16000
 debug_mode: false
 logging: wandb
-log_checkpoints_to_wandb: true
 resume_from_checkpoint: null
 
 training_params:

--- a/representation_learning/api/configs/official_models/openbeats_base.yml
+++ b/representation_learning/api/configs/official_models/openbeats_base.yml
@@ -13,4 +13,3 @@ model_spec:
     normalize: false
     target_length_seconds: 10
     window_selection: random
-    

--- a/representation_learning/api/configs/official_models/openbeats_base.yml
+++ b/representation_learning/api/configs/official_models/openbeats_base.yml
@@ -1,0 +1,16 @@
+---
+# OpenBEATs base model (pretrained) loaded from Hugging Face
+# Default repo id can be overridden via openbeats_repo_id
+model_spec:
+  name: beats
+  pretrained: true
+  beats_variant: openbeats
+  openbeats_size: base
+  device: cuda
+  audio_config:
+    sample_rate: 16000
+    representation: raw  # OpenBEATs expects raw waveform
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+    

--- a/representation_learning/api/configs/official_models/openbeats_large.yml
+++ b/representation_learning/api/configs/official_models/openbeats_large.yml
@@ -1,0 +1,14 @@
+---
+# OpenBEATs large model (pretrained) loaded from Hugging Face
+model_spec:
+  name: beats
+  pretrained: true
+  beats_variant: openbeats
+  openbeats_size: large
+  device: cuda
+  audio_config:
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random

--- a/representation_learning/configs.py
+++ b/representation_learning/configs.py
@@ -255,6 +255,14 @@ class ModelSpec(BaseModel):
     # TODO: general approach for model-specific configs
     use_naturelm: Optional[bool] = Field(None, description="Whether to use NatureLM for BEATs model")
     fine_tuned: Optional[bool] = Field(None, description="Whether to use fine-tuned weights for BEATs model")
+    beats_variant: Optional[Literal["beats", "openbeats"]] = Field(
+        "beats",
+        description="Select between the original BEATs checkpoints and OpenBEATs HuggingFace checkpoints",
+    )
+    openbeats_size: Optional[Literal["base", "large"]] = Field(
+        "base",
+        description="Select between OpenBEATs base or large model variants and checkpoints.",
+    )
 
     # BirdNet-specific configuration
     language: Optional[str] = Field(None, description="Language model for BirdNet (e.g., 'en_us', 'en_uk')")

--- a/representation_learning/models/beats/beats.py
+++ b/representation_learning/models/beats/beats.py
@@ -41,7 +41,8 @@ class BEATsConfig:
         Args:
             cfg: Optional dictionary containing configuration parameters
         """
-        self.input_patch_size: int = -1  # path size of patch embedding
+        # set to 16x16 as a sensible default so that loading from HF works
+        self.input_patch_size: int = 16  # patch size of patch embedding
         self.embed_dim: int = 512  # patch embedding dimension
         self.conv_bias: bool = False  # include bias in conv encoder
 

--- a/representation_learning/models/beats_model.py
+++ b/representation_learning/models/beats_model.py
@@ -4,8 +4,10 @@ This module provides BEATs Bidirectional Encoder representation from Audio Trans
 model implementation for audio representation learning tasks.
 """
 
+import json
 import logging
-from typing import List, Optional, Union
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -23,6 +25,95 @@ BEATS_PRETRAINED_PATH_SSL = "gs://representation-learning/pretrained/BEATs_iter3
 BEATS_PRETRAINED_PATH_NATURELM = (
     "gs://foundation-models/beats_ckpts/BEATs_iter3_plus_AS2M_finetuned_on_AS2M_cpt2_rl_loaded.pt"
 )
+
+OPENBEATS_CHECKPOINTS: Dict[str, Dict[str, str]] = {
+    "base": {"repo": "shikhar7ssu/OpenBEATs-Base-i2", "filename": "model.safetensors"},
+    "large": {"repo": "shikhar7ssu/OpenBEATs-Large-i2", "filename": "model.safetensors"},
+}
+
+
+def _load_openbeats_from_hub(
+    repo_id: str,
+    checkpoint_file: str,
+    *,
+    map_location: str | torch.device = "cpu",
+) -> Tuple[Dict[str, torch.Tensor], Optional[Dict]]:
+    """Download an OpenBEATs checkpoint from Hugging Face and return state + cfg.
+    Returns:
+        (state_dict, cfg_dict) where cfg_dict may be None if missing.
+    Raises:
+        ImportError: if huggingface_hub or safetensors are unavailable.
+        FileNotFoundError: if no checkpoint file is found in the repo snapshot.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception as e:  # pragma: no cover - optional dependency path
+        raise ImportError(
+            "huggingface-hub is required to load OpenBEATs checkpoints. "
+            "Install via `pip install huggingface-hub`."
+        ) from e
+
+    # Download the full snapshot; we search for the checkpoint locally.
+    cache_dir = snapshot_download(repo_id)
+    cache_dir = Path(cache_dir)
+
+    candidates: List[Path] = [cache_dir / checkpoint_file]
+    # shallow fallbacks
+    candidates.extend(cache_dir.glob("*.safetensors"))
+    candidates.extend(cache_dir.glob("*.bin"))
+    candidates.extend(cache_dir.glob("*.pt"))
+
+    checkpoint_path: Optional[Path] = next((p for p in candidates if p.exists()), None)
+
+    # If nothing matched in the root, search recursively (HF repos sometimes nest files)
+    if checkpoint_path is None:
+        recursive = []
+        for pattern in ("*.safetensors", "*.bin", "*.pt"):
+            recursive.extend(sorted(cache_dir.rglob(pattern)))
+        checkpoint_path = recursive[0] if recursive else None
+    if checkpoint_path is None:
+        raise FileNotFoundError(
+            f"No checkpoint file found in {cache_dir}. "
+            "Pass `openbeats_checkpoint_file` to point at a specific file."
+        )
+
+    if checkpoint_path.suffix == ".safetensors":
+        try:
+            from safetensors.torch import load_file as safe_load
+        except Exception as e:  # pragma: no cover - optional dependency path
+            raise ImportError(
+                "safetensors is required to load safetensors OpenBEATs checkpoints. "
+                "Install via `pip install safetensors`."
+            ) from e
+
+        state = safe_load(checkpoint_path, device=map_location)
+    else:
+        state = torch.load(checkpoint_path, map_location=map_location)
+
+    cfg_dict: Optional[Dict] = None
+    state_dict: Dict[str, torch.Tensor]
+
+    if isinstance(state, dict):
+        cfg_dict = state.get("cfg") or state.get("config")
+        if "model" in state:
+            state_dict = state["model"]
+        elif "state_dict" in state:
+            state_dict = state["state_dict"]
+        else:
+            # assume the dict itself is already a state dict
+            state_dict = {k: v for k, v in state.items() if isinstance(v, torch.Tensor)}
+    else:
+        state_dict = state
+
+    if cfg_dict is None:
+        config_json = cache_dir / "config.json"
+        if config_json.exists():
+            try:
+                cfg_dict = json.loads(config_json.read_text())
+            except Exception:
+                logger.warning("Failed to parse OpenBEATs config.json; using defaults.")
+
+    return state_dict, cfg_dict
 
 
 class Model(ModelBase):
@@ -59,6 +150,8 @@ class Model(ModelBase):
         use_naturelm: bool = False,
         fine_tuned: bool = False,
         disable_layerdrop: bool = False,
+        beats_variant: Optional[str] = None,
+        openbeats_size: str = "base",
     ) -> None:
         super().__init__(device=device, audio_config=audio_config)
 
@@ -78,32 +171,50 @@ class Model(ModelBase):
         # ------------------------------------------------------------------
         # 1.  Build the BEATs backbone
         # ------------------------------------------------------------------
+        variant = (beats_variant or "beats").lower()
 
-        if fine_tuned:
-            beats_checkpoint_path = BEATS_PRETRAINED_PATH_FT
+        if variant == "openbeats":
+            ckpt_info = OPENBEATS_CHECKPOINTS.get(openbeats_size, OPENBEATS_CHECKPOINTS["base"])
+            state_dict, cfg_dict = _load_openbeats_from_hub(
+                ckpt_info["repo"],
+                ckpt_info["filename"],
+                map_location="cpu",
+            )
+            beats_cfg = BEATsConfig(cfg_dict or {})
+            self.use_naturelm = False
+            self.fine_tuned = False
+            logger.info(f"Loaded OpenBEATs weights from {ckpt_info['repo']}")
+            self.backbone = BEATs(beats_cfg)
+            self.backbone.to(device)
+            self.backbone.load_state_dict(state_dict, strict=False)
         else:
-            beats_checkpoint_path = BEATS_PRETRAINED_PATH_SSL
+            if fine_tuned:
+                beats_checkpoint_path = BEATS_PRETRAINED_PATH_FT
+            else:
+                beats_checkpoint_path = BEATS_PRETRAINED_PATH_SSL
 
-        beats_ckpt = universal_torch_load(beats_checkpoint_path, cache_mode="use", map_location="cpu")
-        self.use_naturelm = use_naturelm
-        self.fine_tuned = fine_tuned
-        beats_cfg = BEATsConfig(beats_ckpt["cfg"])
-        print(beats_cfg)
-        if use_naturelm:  # BEATs-NatureLM has no config, load from regular ckpt first.
-            beats_ckpt_naturelm = universal_torch_load(BEATS_PRETRAINED_PATH_NATURELM, map_location="cpu")
-        else:
-            beats_ckpt_naturelm = beats_ckpt["model"]
-        # beats_ckpt_naturelm = beats_ckpt
-        self.backbone = BEATs(beats_cfg)
-        self.backbone.to(device)
-        self.backbone.load_state_dict(beats_ckpt_naturelm, strict=False)
+            beats_ckpt = universal_torch_load(beats_checkpoint_path, cache_mode="use", map_location="cpu")
+            self.use_naturelm = use_naturelm
+            self.fine_tuned = fine_tuned
+            beats_cfg = BEATsConfig(beats_ckpt["cfg"])
+            print(beats_cfg)
+            if use_naturelm:  # BEATs-NatureLM has no config, load from regular ckpt first.
+                beats_ckpt_naturelm = universal_torch_load(BEATS_PRETRAINED_PATH_NATURELM, map_location="cpu")
+            else:
+                beats_ckpt_naturelm = beats_ckpt["model"]
+            self.backbone = BEATs(beats_cfg)
+            self.backbone.to(device)
+            self.backbone.load_state_dict(beats_ckpt_naturelm, strict=False)
+
+        # Cache encoder dimension for heads/probes
+        self._encoder_dim = beats_cfg.encoder_embed_dim
 
         # ------------------------------------------------------------------
         # 2.  Optional classifier for supervised training
         # ------------------------------------------------------------------
         self._return_features_only = return_features_only
         if not return_features_only:
-            self.classifier = nn.Linear(768, num_classes)
+            self.classifier = nn.Linear(self._encoder_dim, num_classes)
         else:
             self.register_module("classifier", None)  # type: ignore[arg-type]
 
@@ -170,6 +281,8 @@ class Model(ModelBase):
         self,
         x: torch.Tensor,
         padding_mask: Optional[torch.Tensor] = None,
+        *,
+        framewise: bool = False,
     ) -> torch.Tensor:  # noqa: D401 – keep signature consistent
         """Forward pass.
 
@@ -186,8 +299,9 @@ class Model(ModelBase):
         torch.Tensor
             • When *return_features_only* is **False**: logits of shape
               ``(batch, num_classes)``
-            • Otherwise: unpooled frame-level features of shape
-              ``(batch, num_frames, encoder_embed_dim)``
+            • Otherwise: pooled features of shape ``(batch, encoder_embed_dim)`` by
+              default, or frame-level features ``(batch, num_frames, encoder_embed_dim)``
+              when ``framewise=True``.
         """
         # Optional audio pre-processing
         x = self.process_audio(x)
@@ -198,7 +312,16 @@ class Model(ModelBase):
         # frame_padding: (B, T') or None
 
         if self._return_features_only:
-            return features
+            if framewise:
+                return features
+
+            if frame_padding is not None and frame_padding.any():
+                masked_features = features.clone()
+                masked_features[frame_padding] = 0.0  # Zero-out padded frames
+                valid_counts = (~frame_padding).sum(dim=1, keepdim=True).clamp(min=1)
+                return masked_features.sum(dim=1) / valid_counts
+
+            return features.mean(dim=1)
 
         # ------------------------------------------------------------------
         # 3.  Masked mean-pooling over the temporal dimension

--- a/representation_learning/models/beats_model.py
+++ b/representation_learning/models/beats_model.py
@@ -49,8 +49,7 @@ def _load_openbeats_from_hub(
         from huggingface_hub import snapshot_download
     except Exception as e:  # pragma: no cover - optional dependency path
         raise ImportError(
-            "huggingface-hub is required to load OpenBEATs checkpoints. "
-            "Install via `pip install huggingface-hub`."
+            "huggingface-hub is required to load OpenBEATs checkpoints. Install via `pip install huggingface-hub`."
         ) from e
 
     # Download the full snapshot; we search for the checkpoint locally.
@@ -73,8 +72,7 @@ def _load_openbeats_from_hub(
         checkpoint_path = recursive[0] if recursive else None
     if checkpoint_path is None:
         raise FileNotFoundError(
-            f"No checkpoint file found in {cache_dir}. "
-            "Pass `openbeats_checkpoint_file` to point at a specific file."
+            f"No checkpoint file found in {cache_dir}. Pass `openbeats_checkpoint_file` to point at a specific file."
         )
 
     if checkpoint_path.suffix == ".safetensors":

--- a/representation_learning/models/get_model.py
+++ b/representation_learning/models/get_model.py
@@ -124,6 +124,9 @@ def get_model(model_config: ModelSpec, num_classes: int) -> ModelBase:
         fine_tuned = getattr(model_config, "fine_tuned", False)
         disable_layerdrop = getattr(model_config, "disable_layerdrop", False)
 
+        beats_variant = getattr(model_config, "beats_variant", None)
+        openbeats_size = getattr(model_config, "openbeats_size", "base")
+
         return BeatsModel(
             num_classes=num_classes,
             pretrained=model_config.pretrained,
@@ -132,6 +135,8 @@ def get_model(model_config: ModelSpec, num_classes: int) -> ModelBase:
             use_naturelm=use_naturelm,
             fine_tuned=fine_tuned,
             disable_layerdrop=disable_layerdrop,
+            beats_variant=beats_variant,
+            openbeats_size=openbeats_size,
         )
     elif model_name == "eat_hf":
         from representation_learning.models.eat_hf import (


### PR DESCRIPTION
OpenBEATs implementation in the same class as BEATs. Uses the default architecture in the paper, not ablations. Adds beat_variant option, which can be specified as 'beats' or 'openbeats', and openbeats_size, which can be specified as 'base' or 'large'. Loads the OpenBEATs checkpoints from huggingface, unless overwritten by a checkpoint path. Added a few configs for finetuning/eval as well, not sure if necessary.