### PR TITLE
fix beats default value

### DIFF
--- a/representation_learning/models/beats/beats.py
+++ b/representation_learning/models/beats/beats.py
@@ -37,7 +37,7 @@ class BEATsConfig(BaseModel):
     """Configuration class for BEATs model parameters."""
 
     # patch embedding
-    input_patch_size: int = -1  # path size of patch embedding
+    input_patch_size: int = 16  # path size of patch embedding
     embed_dim: int = 512  # patch embedding dimension
     conv_bias: bool = False  # include bias in conv encoder
 


### PR DESCRIPTION
I noticed that if you instantiate beats with the default values in the config you get a failure:

```
RuntimeError: Trying to create tensor with negative dimension -1: [512, 1, -1, -1]
```

This PR fixes that


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"beats-config","parentHead":"e2b0b99f4e43a77fbcf52f24c9adc52cbdcda53b","parentPull":124,"trunk":"v2-dev"}
```
-->
