### PR TITLE
efficientnet.forward should have padding_mask  Optional

### DIFF
--- a/representation_learning/models/efficientnet.py
+++ b/representation_learning/models/efficientnet.py
@@ -177,15 +177,20 @@ class Model(ModelBase):
         """
         return torch.utils.checkpoint.checkpoint(self.model.features, x, use_reentrant=False)
 
-    def forward(self, x: torch.Tensor, padding_mask: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Forward pass through the model.
 
         Parameters
         ----------
         x : torch.Tensor
             Input audio tensor
-        padding_mask : torch.Tensor
-            Padding mask for the input
+        padding_mask : torch.Tensor | None, optional
+            Padding mask for the input. Currently ignored for EfficientNet models
+            but kept for API compatibility across architectures.
 
         Returns
         -------

--- a/tests/unittests/test_efficientnet.py
+++ b/tests/unittests/test_efficientnet.py
@@ -17,10 +17,16 @@ def test_efficientnet() -> None:
     # EfficientNet B0 expects images of at least 224x224 in size.
     dummy_input = torch.randn(8, 3, 224, 224).to(device)
 
-    # Perform a forward pass (EfficientNet requires padding_mask)
+    # Test forward pass without padding_mask (padding_mask defaults to None)
+    outputs = model(dummy_input)
+    assert outputs.shape == (8, 1000), f"Expected shape (8, 1000), got {outputs.shape}"
+    print("Output shape (without padding_mask):", outputs.shape)
+
+    # Test forward pass with explicit padding_mask (should also work)
     padding_mask = torch.zeros(8, 224 * 224, dtype=torch.bool).to(device)
-    outputs = model(dummy_input, padding_mask)
-    print("Output shape:", outputs.shape)
+    outputs_with_mask = model(dummy_input, padding_mask)
+    assert outputs_with_mask.shape == (8, 1000), f"Expected shape (8, 1000), got {outputs_with_mask.shape}"
+    print("Output shape (with padding_mask):", outputs_with_mask.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix for #128 
efficientnet is the only model for which padding_mask is required, it should be Optional 