### PR TITLE
effnet loading bugfix

### DIFF
--- a/representation_learning/models/utils/load.py
+++ b/representation_learning/models/utils/load.py
@@ -543,7 +543,13 @@ def _load_checkpoint(model: object, checkpoint_path: str, device: str, keep_clas
     checkpoint = universal_torch_load(ckpt_path, map_location=device)
 
     # Process state dict if needed
-    state_dict = _process_state_dict(checkpoint, keep_classifier=keep_classifier)
+    target_keys = model.state_dict().keys()
+    target_has_model_prefix = any(k.startswith("model.") for k in target_keys)
+    state_dict = _process_state_dict(
+        checkpoint,
+        keep_classifier=keep_classifier,
+        drop_model_prefix=not target_has_model_prefix,
+    )
 
     # Load weights
     model.load_state_dict(state_dict, strict=False)

--- a/representation_learning/utils/utils.py
+++ b/representation_learning/utils/utils.py
@@ -247,7 +247,7 @@ def universal_torch_load(
 # -------------------------------------------------------------------- #
 
 
-def _process_state_dict(state_dict: dict, keep_classifier: bool = False) -> dict:
+def _process_state_dict(state_dict: dict, keep_classifier: bool = False, drop_model_prefix: bool = True) -> dict:
     """Process state dict to handle common prefixes and optionally remove
     classifier layers.
 
@@ -263,6 +263,10 @@ def _process_state_dict(state_dict: dict, keep_classifier: bool = False) -> dict
     keep_classifier : bool, default False
         If True, keep classifier/head layers in the output.
         If False (default), remove classifier layers for backbone loading.
+    drop_model_prefix : bool, default True
+        If True, strip leading ``model.`` from parameter names (common in
+        DDP/lightning checkpoints). Set to False when the target model's
+        parameters already include the ``model.`` prefix to avoid mismatches.
 
     Returns
     -------
@@ -291,7 +295,7 @@ def _process_state_dict(state_dict: dict, keep_classifier: bool = False) -> dict
         processed_key = key
         if processed_key.startswith("module."):
             processed_key = processed_key[7:]  # Remove "module."
-        elif processed_key.startswith("model."):
+        elif drop_model_prefix and processed_key.startswith("model."):
             processed_key = processed_key[6:]  # Remove "model."
 
         # Conditionally skip classifier layers based on keep_classifier parameter


### PR DESCRIPTION
I *think* this fixes the bug where the trained model head was not loading, and was using randomly initialized weights. I confirmed on data that the distribution of logits is no longer centered at zero, and is instead distributed more like we'd expect.

@david-rx can you confirm that you can reproduce your CBI results with this change? Also tagged @nkundiushuti in case this breaks compatibility with other models.