### PR TITLE
fix(example 05): load EAT with return_features_only=True for embedding demo

### DIFF
--- a/examples/05_embedding_extraction.py
+++ b/examples/05_embedding_extraction.py
@@ -69,7 +69,8 @@ def main(device: str = "cpu") -> None:
     print("\nPart 2: EAT (Transformer)")
     print("-" * 50)
 
-    model = load_model("sl_eat_animalspeak_ssl_all", device=device)
+    # This model has a classifier; request embedding output for this example.
+    model = load_model("sl_eat_animalspeak_ssl_all", device=device, return_features_only=True)
     model.eval()
 
     print(f"Loaded model: {type(model).__name__}")


### PR DESCRIPTION
Part 2 of `examples/05_embedding_extraction.py` loads `sl_eat_animalspeak_ssl_all`, which has a classifier. The example is intended to show embedding (3D) output, so we request `return_features_only=True` so it prints (batch, patches, features) instead of failing on 2D logits.

**Changes**
- `examples/05_embedding_extraction.py`: pass `return_features_only=True` when loading the EAT model in Part 2 and add a short comment.

**Only file changed:** `examples/05_embedding_extraction.py` (branch is based on `main` only).