### PR TITLE
float32 casting in effnet

### DIFF
--- a/representation_learning/models/efficientnet.py
+++ b/representation_learning/models/efficientnet.py
@@ -151,13 +151,18 @@ class Model(ModelBase):
         Parameters
         ----------
         x : torch.Tensor
-            Input audio tensor
+            Input audio tensor (will be automatically cast to float32 if needed)
 
         Returns
         -------
         torch.Tensor
             Processed audio tensor with 3 channels for EfficientNet (B0/B1)
         """
+        # Ensure audio is float32 (required to match mel_basis dtype in mel_spectrogram processing)
+        # The mel_basis (MelScale) is float32, so float64 input causes dtype mismatch errors
+        if x.dtype != torch.float32:
+            x = x.to(torch.float32)
+
         # First use parent's audio processing
         x = super().process_audio(x)
 

--- a/tests/unittests/test_efficientnet.py
+++ b/tests/unittests/test_efficientnet.py
@@ -1,5 +1,6 @@
 import torch
 
+from representation_learning.configs import AudioConfig
 from representation_learning.models.efficientnet import Model as EfficientNet
 
 
@@ -29,5 +30,52 @@ def test_efficientnet() -> None:
     print("Output shape (with padding_mask):", outputs_with_mask.shape)
 
 
+def test_efficientnet_float64_audio_input() -> None:
+    """Test that EfficientNet automatically converts float64 audio to float32.
+
+    This test verifies the fix for issue #145 where EfficientNet would fail
+    silently or produce errors when audio input was float64 instead of float32.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Create audio config for spectrogram processing
+    audio_config = AudioConfig(
+        sample_rate=16000,
+        n_fft=2048,
+        hop_length=512,
+        win_length=2048,
+        window="hann",
+        n_mels=128,
+        representation="mel_spectrogram",
+        normalize=False,
+        target_length_seconds=5,
+        window_selection="random",
+    )
+
+    # Create EfficientNet model with audio config
+    model = EfficientNet(
+        num_classes=10,
+        pretrained=False,  # Use False for faster testing
+        device=device,
+        audio_config=audio_config,
+        return_features_only=True,
+    )
+    model.eval()
+
+    # Create audio input with float64 dtype (the problematic case)
+    # 5 seconds of audio at 16kHz = 80000 samples
+    audio_input = torch.randn(2, 80000, dtype=torch.float64).to(device)
+
+    # This should work without errors - the model should automatically convert to float32
+    with torch.no_grad():
+        output = model(audio_input)
+
+    # Verify output shape is correct (batch, channels, height, width)
+    assert output.dtype == torch.float32, "Output should be float32"
+    assert len(output.shape) == 4, "Output should be 4D (B, C, H, W)"
+    print(f"Successfully processed float64 audio input. Output shape: {output.shape}")
+
+
 if __name__ == "__main__":
     test_efficientnet()
+    test_efficientnet_float64_audio_input()


### PR DESCRIPTION
## Fix: EfficientNet auto-converts float64 audio to float32

Fixes #145

**Problem:** EfficientNet fails with dtype mismatch when audio input is float64. The `mel_basis` (MelScale) is float32, but float64 input produces float64 spectrogram, causing: "expected m1 and m2 to have the same dtype, but got: double != float".

**Solution:** Automatically convert audio to float32 in `EfficientNet.process_audio()` before processing.

**Changes:**
- Auto-convert to float32 if needed
- Updated docstring
- Added test for float64 input handling