### PR TITLE
Add CODEOWNERS for PR approval requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,12 @@
 # NOTE: Teams must have explicit write access to the repository.
 # Order matters - last matching pattern takes precedence.
 
-# Default: AI team owns everything
-*                       @earthspecies/ai-fte
+# Default: infra-humans team + specific users own everything
+*                       @earthspecies/infra-humans @david-rx @nkundiushuti
 
 # Humans team can approve docs and READMEs
 /docs/                  @earthspecies/humans
 *.md                    @earthspecies/humans
 
-# Protect CODEOWNERS itself - requires AI team approval
-/.github/CODEOWNERS     @earthspecies/ai-fte
+# Protect CODEOWNERS itself - requires infra team approval
+/.github/CODEOWNERS     @earthspecies/infra-humans @david-rx @nkundiushuti


### PR DESCRIPTION
## Summary

- Adds CODEOWNERS file to enforce team-based PR approvals
- AI team (`@earthspecies/ai-fte`) owns all code by default
- Humans team (`@earthspecies/humans`) can approve docs and markdown files
- CODEOWNERS file itself is protected (requires AI team approval)

## Setup required after merge

Enable in repo **Settings** → **Branches** → branch protection for `main`:
- ✅ Require review from Code Owners