### PR TITLE
Fix EfficientNet AMP NaN grads (FP16-only guard)

### DIFF
--- a/avex/models/efficientnet.py
+++ b/avex/models/efficientnet.py
@@ -218,10 +218,22 @@ class Model(ModelBase):
         x = self.process_audio(x)
 
         # Extract features with optional gradient checkpointing
-        if self.gradient_checkpointing and self.training:
-            features = self._checkpointed_features(x)
+        # Empirically, EfficientNet's backward under CUDA autocast can produce NaN
+        # gradients even when activations and loss are finite. When autocast is
+        # enabled, run the feature extractor in FP32 for stability while keeping
+        # AMP for the rest of the training loop.
+        needs_guard = x.is_cuda and torch.is_autocast_enabled() and torch.get_autocast_dtype("cuda") == torch.float16
+        if needs_guard:
+            with torch.autocast(device_type="cuda", enabled=False):
+                if self.gradient_checkpointing and self.training:
+                    features = self._checkpointed_features(x.float())
+                else:
+                    features = self.model.features(x.float())
         else:
-            features = self.model.features(x)
+            if self.gradient_checkpointing and self.training:
+                features = self._checkpointed_features(x)
+            else:
+                features = self.model.features(x)
 
         # Return unpooled spatial features if requested
         if self.return_features_only:

--- a/avex/models/efficientnet.py
+++ b/avex/models/efficientnet.py
@@ -4,6 +4,7 @@ This module provides EfficientNet model implementations for audio classification
 tasks, including B0 and B1 variants with audio-specific preprocessing.
 """
 
+import contextlib
 import logging
 from typing import List, Optional, Union
 
@@ -217,32 +218,34 @@ class Model(ModelBase):
         # Process audio
         x = self.process_audio(x)
 
-        # Extract features with optional gradient checkpointing
-        # Empirically, EfficientNet's backward under CUDA autocast can produce NaN
-        # gradients even when activations and loss are finite. When autocast is
-        # enabled, run the feature extractor in FP32 for stability while keeping
-        # AMP for the rest of the training loop.
-        needs_guard = x.is_cuda and torch.is_autocast_enabled() and torch.get_autocast_dtype("cuda") == torch.float16
-        if needs_guard:
-            with torch.autocast(device_type="cuda", enabled=False):
-                if self.gradient_checkpointing and self.training:
-                    features = self._checkpointed_features(x.float())
-                else:
-                    features = self.model.features(x.float())
-        else:
+        # Empirically, EfficientNet's backward under CUDA FP16 autocast can produce NaN
+        # gradients even when activations and loss are finite. When this is the case, run
+        # the full forward pass in FP32 for stability while keeping AMP for the rest of
+        # the training loop. bfloat16 is excluded because its exponent range matches
+        # float32 and does not exhibit this issue.
+        # The guard is gated on is_grad_enabled() so eval/torch.no_grad() paths retain
+        # full FP16 throughput and memory benefits.
+        needs_guard = (
+            x.is_cuda
+            and torch.is_grad_enabled()
+            and torch.is_autocast_enabled()
+            and torch.get_autocast_dtype("cuda") == torch.float16
+        )
+        ctx = torch.autocast(device_type="cuda", enabled=False) if needs_guard else contextlib.nullcontext()
+        x_in = x.float() if needs_guard else x
+
+        with ctx:
             if self.gradient_checkpointing and self.training:
-                features = self._checkpointed_features(x)
+                features = self._checkpointed_features(x_in)
             else:
-                features = self.model.features(x)
+                features = self.model.features(x_in)
 
-        # Return unpooled spatial features if requested
-        if self.return_features_only:
-            return features
+            if self.return_features_only:
+                return features
 
-        pooled_features = self.model.avgpool(features)
-        flattened_features = torch.flatten(pooled_features, 1)
-        logits = self.model.classifier(flattened_features)
-        return logits
+            pooled_features = self.model.avgpool(features)
+            flattened_features = torch.flatten(pooled_features, 1)
+            return self.model.classifier(flattened_features)
 
     def extract_embeddings(
         self,

--- a/tests/unittests/test_efficientnet.py
+++ b/tests/unittests/test_efficientnet.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from avex.configs import AudioConfig
@@ -74,6 +75,32 @@ def test_efficientnet_float64_audio_input() -> None:
     assert output.dtype == torch.float32, "Output should be float32"
     assert len(output.shape) == 4, "Output should be 4D (B, C, H, W)"
     print(f"Successfully processed float64 audio input. Output shape: {output.shape}")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_efficientnet_amp_guard() -> None:
+    """Test that the FP32 guard activates during FP16 autocast training but not during eval/no_grad.
+
+    During training with FP16 autocast, EfficientNet's feature extractor is forced to FP32
+    to avoid NaN gradients. During eval or torch.no_grad(), gradients are absent so the
+    guard should not activate, preserving FP16 throughput/memory benefits.
+    """
+    device = torch.device("cuda")
+    model = EfficientNet(num_classes=10, pretrained=False, device=device, return_features_only=True)
+    model.to(device)
+    dummy_input = torch.randn(2, 3, 224, 224, device=device)
+
+    # Training + FP16 autocast: guard should activate → features in FP32
+    model.train()
+    with torch.autocast(device_type="cuda", dtype=torch.float16):
+        features = model(dummy_input)
+    assert features.dtype == torch.float32, f"Expected FP32 features during training+autocast, got {features.dtype}"
+
+    # Eval + no_grad + FP16 autocast: guard should NOT activate → features in FP16
+    model.eval()
+    with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.float16):
+        features = model(dummy_input)
+    assert features.dtype == torch.float16, f"Expected FP16 features during eval+no_grad+autocast, got {features.dtype}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix for #169 
This fixes a reproducible fine-tuning failure where esp_aves2_effnetb0_all (and the Animalspeak checkpoint) produce NaN gradients under CUDA autocast FP16 while forward/loss remain finite. The fix runs EfficientNet’s model.features(...) in FP32 only when autocast dtype is FP16, keeping BF16 autocast unaffected. Verified via tmp_bn_nan_repro.py on gs://representation-learning/models/efficientnet_animalspeak.pt with AMP enabled.