### PR TITLE
Release v1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avex"
-version = "1.1.0"
+version = "1.1.1"
 description = "A comprehensive Python-based system for training, evaluating, and analyzing audio representation learning models with support for both supervised and self-supervised learning paradigms"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 
 [[package]]
 name = "avex"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "birdnetlib" },


### PR DESCRIPTION
## Summary
- Bump package version to v1.1.1 so the current `main` fixes can be released as a patch.

## Test plan
- [x] `uv sync`
- [x] `uv run pytest`
- [x] Install from the built artifact and sanity-check BEATs official model config loading