### PR TITLE
Make librosa an optional 'examples' dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 
 dependencies = [
-  "librosa>=0.11.0",
   "numpy>=1.26.4",
   "omegaconf>=2.3.0",
   "pydantic>=2.11.3",
@@ -42,6 +41,7 @@ dependencies = [
   "tensorflow>=2.21.0; python_version < '3.14'",
   "tensorflow-hub>=0.16.1; python_version < '3.14'",
   "einops>=0.8.1",
+  "scikit-learn>=1.6.0",
   "pydantic-settings>=2.9.1",
   "fsspec>=2024.2.0",
   "gcsfs>=2024.2.0",
@@ -50,6 +50,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+examples = [
+  "librosa>=0.11.0",
+]
 dev = [
   "pytorch-lightning>=2.5.1.post0",
   "mlflow>=2.22.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,12 +28,6 @@ async-timeout==5.0.1 ; python_full_version < '3.11'
     # via aiohttp
 attrs==26.1.0
     # via aiohttp
-audioop-lts==0.2.2 ; python_full_version >= '3.13'
-    # via
-    #   standard-aifc
-    #   standard-sunau
-audioread==3.1.0
-    # via librosa
 birdnetlib==0.18.0
     # via avex
 bitsandbytes==0.49.2 ; sys_platform != 'darwin'
@@ -64,9 +58,7 @@ cuda-toolkit==13.0.2 ; sys_platform == 'linux'
 cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
-    # via
-    #   gcsfs
-    #   librosa
+    # via gcsfs
 einops==0.8.2
     # via avex
 filelock==3.25.2
@@ -163,23 +155,15 @@ jmespath==1.1.0
     #   aiobotocore
     #   botocore
 joblib==1.5.3
-    # via
-    #   librosa
-    #   scikit-learn
+    # via scikit-learn
 keras==3.12.1 ; python_full_version < '3.11'
     # via tensorflow
 keras==3.14.0 ; python_full_version >= '3.11'
     # via tensorflow
 kiwisolver==1.5.0
     # via matplotlib
-lazy-loader==0.5
-    # via librosa
 libclang==18.1.1
     # via tensorflow
-librosa==0.11.0
-    # via avex
-llvmlite==0.47.0
-    # via numba
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
@@ -194,8 +178,6 @@ ml-dtypes==0.5.4
     #   tensorflow
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.2
-    # via librosa
 multidict==6.7.1
     # via
     #   aiobotocore
@@ -207,8 +189,6 @@ networkx==3.4.2 ; python_full_version < '3.11'
     # via torch
 networkx==3.6.1 ; python_full_version >= '3.11'
     # via torch
-numba==0.65.0
-    # via librosa
 numpy==2.2.6 ; python_full_version < '3.11'
     # via
     #   avex
@@ -216,15 +196,12 @@ numpy==2.2.6 ; python_full_version < '3.11'
     #   contourpy
     #   h5py
     #   keras
-    #   librosa
     #   matplotlib
     #   ml-dtypes
-    #   numba
     #   pandas
     #   scikit-learn
     #   scipy
     #   soundfile
-    #   soxr
     #   tensorflow
     #   tensorflow-hub
     #   torchvision
@@ -236,15 +213,12 @@ numpy==2.4.4 ; python_full_version >= '3.11'
     #   contourpy
     #   h5py
     #   keras
-    #   librosa
     #   matplotlib
     #   ml-dtypes
-    #   numba
     #   pandas
     #   scikit-learn
     #   scipy
     #   soundfile
-    #   soxr
     #   tensorflow
     #   tensorflow-hub
     #   torchvision
@@ -301,9 +275,7 @@ packaging==26.0
     #   bitsandbytes
     #   huggingface-hub
     #   keras
-    #   lazy-loader
     #   matplotlib
-    #   pooch
     #   tensorflow
     #   transformers
     #   wheel
@@ -313,10 +285,6 @@ pillow==11.3.0
     # via
     #   matplotlib
     #   torchvision
-platformdirs==4.9.6
-    # via pooch
-pooch==1.9.0
-    # via librosa
 propcache==0.4.1
     # via
     #   aiohttp
@@ -381,7 +349,6 @@ requests==2.33.1
     #   google-api-core
     #   google-cloud-storage
     #   huggingface-hub
-    #   pooch
     #   requests-oauthlib
     #   tensorflow
     #   transformers
@@ -396,17 +363,13 @@ safetensors==0.7.0
     #   timm
     #   transformers
 scikit-learn==1.7.2 ; python_full_version < '3.11'
-    # via librosa
+    # via avex
 scikit-learn==1.8.0 ; python_full_version >= '3.11'
-    # via librosa
+    # via avex
 scipy==1.15.3 ; python_full_version < '3.11'
-    # via
-    #   librosa
-    #   scikit-learn
+    # via scikit-learn
 scipy==1.17.1 ; python_full_version >= '3.11'
-    # via
-    #   librosa
-    #   scikit-learn
+    # via scikit-learn
 setuptools==81.0.0
     # via
     #   tensorflow
@@ -418,21 +381,7 @@ six==1.17.0
     #   python-dateutil
     #   tensorflow
 soundfile==0.13.1
-    # via
-    #   avex
-    #   librosa
-soxr==1.0.0
-    # via librosa
-standard-aifc==3.13.0 ; python_full_version >= '3.13'
-    # via
-    #   audioread
-    #   librosa
-standard-chunk==3.13.0 ; python_full_version >= '3.13'
-    # via standard-aifc
-standard-sunau==3.13.0 ; python_full_version >= '3.13'
-    # via
-    #   audioread
-    #   librosa
+    # via avex
 sympy==1.14.0
     # via torch
 tensorflow==2.21.0
@@ -479,7 +428,6 @@ typing-extensions==4.15.0
     #   cryptography
     #   grpcio
     #   huggingface-hub
-    #   librosa
     #   multidict
     #   optree
     #   pydantic

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,6 @@ dependencies = [
     { name = "gcsfs" },
     { name = "h5py" },
     { name = "huggingface-hub" },
-    { name = "librosa" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "omegaconf" },
@@ -479,6 +478,8 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "s3fs" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "soundfile" },
     { name = "tensorflow" },
     { name = "tensorflow-hub" },
@@ -499,6 +500,9 @@ dev = [
     { name = "mlflow" },
     { name = "pytorch-lightning" },
     { name = "wandb" },
+]
+examples = [
+    { name = "librosa" },
 ]
 
 [package.dev-dependencies]
@@ -536,7 +540,7 @@ requires-dist = [
     { name = "gradio-leaderboard", marker = "extra == 'dev'", specifier = ">=0.0.13" },
     { name = "h5py", specifier = ">=3.13.0" },
     { name = "huggingface-hub", specifier = ">=0.36.0" },
-    { name = "librosa", specifier = ">=0.11.0" },
+    { name = "librosa", marker = "extra == 'examples'", specifier = ">=0.11.0" },
     { name = "mlflow", marker = "extra == 'dev'", specifier = ">=2.22.0" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "omegaconf", specifier = ">=2.3.0" },
@@ -546,6 +550,7 @@ requires-dist = [
     { name = "pytorch-lightning", marker = "extra == 'dev'", specifier = ">=2.5.1.post0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "s3fs", specifier = ">=2024.2.0" },
+    { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "soundfile", specifier = ">=0.13.1" },
     { name = "tensorflow", marker = "python_full_version < '3.14'", specifier = ">=2.21.0" },
     { name = "tensorflow-hub", marker = "python_full_version < '3.14'", specifier = ">=0.16.1" },
@@ -557,7 +562,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.0.0" },
     { name = "wandb", marker = "extra == 'dev'", specifier = ">=0.21.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["examples", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

Move `librosa` from required `[project].dependencies` to a new optional-dependency extra `examples`.

```toml
[project.optional-dependencies]
examples = [
  "librosa>=0.11.0",
]
```

Install with examples deps: `pip install avex[examples]` / `uv sync --extra examples`.

## Why

`librosa` is not imported anywhere in the `avex/` package — it only appears in `examples/*.py` (resample snippets). Keeping it as a hard dep pulls the `librosa → numba → llvmlite` chain into every install.

Fixes the class of problem in #197: downstream resolvers can walk that chain back to ancient `numba` (e.g. `0.53.1`, which pins `<3.10`) and fail on Python 3.11/3.12. Core `avex` no longer forces librosa, so lean installs stay clean.

## Notes

- `uv.lock` regenerated.
- Does not touch `requires-python` — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)