### PR TITLE
ICASSP 2026: EAT SSL eval + supervised post-training on AudioSet+Xeno+iNat

### DIFF
--- a/.dict-allowed.txt
+++ b/.dict-allowed.txt
@@ -10,3 +10,4 @@ Anseriformes
 ### Non-English ###
 
 
+te

--- a/avex/data/augmentations.py
+++ b/avex/data/augmentations.py
@@ -178,7 +178,7 @@ class AugmentationProcessor:
     # ------------------------------------------------------------------
     # Item-level noise augmentation
     # ------------------------------------------------------------------
-    def _apply_noise(self, wav: torch.Tensor) -> torch.Tensor:
+    def _apply_noise(self, wav: torch.Tensor) -> tuple[torch.Tensor, bool]:
         """Apply noise augmentation to a single audio sample.
 
         Parameters
@@ -188,15 +188,18 @@ class AugmentationProcessor:
 
         Returns
         -------
-        torch.Tensor
-            Audio tensor with noise augmentation applied.
+        tuple[torch.Tensor, bool]
+            The augmented audio tensor, and whether the original signal was
+            masked out (replaced by pure noise) — in which case the caller must
+            also clear the label, since no target class is present anymore.
 
         """
         # Skip noise augmentation if audio has zero length
         if wav.numel() == 0 or wav.shape[-1] == 0:
             logger.warning(f"Skipping noise augmentation for audio with zero length: shape={wav.shape}")
-            return wav
+            return wav, False
 
+        signal_masked = False
         for cfg in self.noise_aug_configs:
             if random.random() >= cfg.augmentation_prob:  # noqa: S311
                 continue
@@ -211,6 +214,7 @@ class AugmentationProcessor:
             mask_signal = random.random() < cfg.mask_signal_prob  # noqa: S311
             try:
                 wav = self._mix_noise(wav, noise_path, cfg.snr_db_range, mask_signal=mask_signal)
+                signal_masked = signal_masked or mask_signal
             except Exception as exc:  # noqa: BLE001
                 # Log full stack trace for later debugging
                 logger.exception(
@@ -219,7 +223,7 @@ class AugmentationProcessor:
                     exc,
                 )
 
-        return wav
+        return wav, signal_masked
 
     def _localize_noise_path(self, noise_path: AnyPathT) -> str:
         """Return a local path for ``noise_path``, downloading from cloud if needed.
@@ -429,7 +433,12 @@ class AugmentationProcessor:
         # Use "audio" key if available, fallback to "raw_wav" for compatibility
         audio_key = "audio" if "audio" in item_dict else "raw_wav"
         wav: torch.Tensor = item_dict[audio_key].to(self.device)
-        aug_item[audio_key] = self._apply_noise(wav)
+        aug_wav, signal_masked = self._apply_noise(wav)
+        aug_item[audio_key] = aug_wav
+        # If the signal was replaced by pure noise, no target class is present:
+        # clear the (multi-label) label so it collates to an all-zero target.
+        if signal_masked and isinstance(aug_item.get("label"), (list, np.ndarray, torch.Tensor)):
+            aug_item["label"] = []
         return aug_item
 
     # ------------------------------------------------------------------

--- a/avex/data/augmentations.py
+++ b/avex/data/augmentations.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import random
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -18,9 +19,10 @@ import numpy as np
 import soundfile as sf
 import torch
 import torchaudio
-from alp_data.io import AnyPathT, anypath
+from alp_data.io import AnyPathT
 
 from avex.data.data_utils import combine_text_labels
+from avex.io.filesystem import filesystem_from_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -108,8 +110,12 @@ class AugmentationProcessor:
         self.noise_aug_configs = [spec for spec in augmentation_specs if isinstance(spec, NoiseAugment)]
         self.mixup_aug_configs = [spec for spec in augmentation_specs if isinstance(spec, MixupAugment)]
 
+        # Local cache for noise files fetched from cloud storage (gs://, s3://, …),
+        # since soundfile/torchaudio only read local paths.
+        self._noise_cache_dir = Path(tempfile.gettempdir()) / "avex_noise_cache"
+
         # Pre-collect noise file lists to avoid repeated directory scanning
-        self._noise_pools: dict[int, list[Path]] = {}
+        self._noise_pools: dict[int, list[str]] = {}
         for cfg in self.noise_aug_configs:
             try:
                 self._noise_pools[id(cfg)] = self._list_noise_files(cfg.noise_dirs)
@@ -125,8 +131,11 @@ class AugmentationProcessor:
     def _list_noise_files(
         noise_dirs: Sequence[str],
         max_noise_samples: int = 10000,
-    ) -> list[Path]:
+    ) -> list[str]:
         """Enumerate all candidate noise files across noise directories.
+
+        Uses an fsspec filesystem so both local paths and cloud URIs
+        (``gs://``, ``s3://`` …) are supported.
 
         Parameters
         ----------
@@ -137,8 +146,8 @@ class AugmentationProcessor:
 
         Returns
         -------
-        list[Path]
-            List of noise file paths found in the directories.
+        list[str]
+            List of noise file paths (full URIs, protocol preserved).
 
         Raises
         ------
@@ -146,16 +155,23 @@ class AugmentationProcessor:
             If any of the specified noise directories do not exist.
 
         """
-        noise_paths: list[Path] = []
+        noise_paths: list[str] = []
         for dir_str in noise_dirs:
-            dir_path: AnyPathT = anypath(dir_str)
-            if not dir_path.exists():
+            d = str(dir_str).rstrip("/")
+            proto = d.split("://", 1)[0] + "://" if "://" in d else ""
+            fs = filesystem_from_path(d)
+            if not fs.exists(d):
                 msg = f"Noise directory not found: {dir_str}"
                 raise FileNotFoundError(msg)
 
             for ext in (".wav", ".mp3", ".flac", ".ogg"):
-                noise_files = list(dir_path.glob(f"*{ext}"))[:max_noise_samples]
-                noise_paths.extend(noise_files)
+                matches = fs.glob(f"{d}/*{ext}")[:max_noise_samples]
+                for m in matches:
+                    m = str(m)
+                    # fsspec cloud filesystems return protocol-less keys -> re-add it
+                    if proto and not m.startswith(proto):
+                        m = proto + m.lstrip("/")
+                    noise_paths.append(m)
         logger.info("Found %d noise files", len(noise_paths))
         return noise_paths
 
@@ -190,8 +206,11 @@ class AugmentationProcessor:
                 continue
 
             noise_path = random.choice(noise_candidates)  # noqa: S311
+            # With mask_signal_prob, drop the original signal and keep only the
+            # (power-matched) noise — "mask the signal, use only noise".
+            mask_signal = random.random() < cfg.mask_signal_prob  # noqa: S311
             try:
-                wav = self._mix_noise(wav, noise_path, cfg.snr_db_range)
+                wav = self._mix_noise(wav, noise_path, cfg.snr_db_range, mask_signal=mask_signal)
             except Exception as exc:  # noqa: BLE001
                 # Log full stack trace for later debugging
                 logger.exception(
@@ -201,6 +220,26 @@ class AugmentationProcessor:
                 )
 
         return wav
+
+    def _localize_noise_path(self, noise_path: AnyPathT) -> str:
+        """Return a local path for ``noise_path``, downloading from cloud if needed.
+
+        soundfile/torchaudio only read local files, so cloud URIs (``gs://`` …) are
+        fetched once into a local cache and reused thereafter.
+
+        Returns
+        -------
+        str
+            A local filesystem path to the (possibly cached) noise file.
+        """
+        p = str(noise_path)
+        if "://" not in p:
+            return p  # already local
+        cached = self._noise_cache_dir / p.split("://", 1)[1]
+        if not cached.exists():
+            cached.parent.mkdir(parents=True, exist_ok=True)
+            filesystem_from_path(p).get(p, str(cached))
+        return str(cached)
 
     def _load_noise_segment(
         self,
@@ -213,7 +252,7 @@ class AugmentationProcessor:
         Parameters
         ----------
         noise_path : AnyPathT
-            Path to noise file.
+            Path to noise file (local or cloud URI).
         audio_len : int
             Target audio length in samples.
         max_window_sec : float
@@ -225,6 +264,7 @@ class AugmentationProcessor:
             Processed noise audio tensor.
 
         """
+        noise_path = self._localize_noise_path(noise_path)
         info = sf.info(str(noise_path))
         target_frames = min(int(self.sr * max_window_sec), audio_len)
 
@@ -255,11 +295,16 @@ class AugmentationProcessor:
             return torch.zeros((1, 1), dtype=torch.float32)
 
         try:
-            noise_wav, noise_sr = torchaudio.load(
-                noise_path,
-                frame_offset=frame_offset,
-                num_frames=num_frames,
+            # Read with soundfile (torchaudio.load needs the torchcodec backend,
+            # which is not installed with torch>=2.11). Returns (frames, channels).
+            noise_np, noise_sr = sf.read(
+                str(noise_path),
+                start=frame_offset,
+                frames=num_frames,
+                dtype="float32",
+                always_2d=True,
             )
+            noise_wav = torch.from_numpy(noise_np.T)  # -> (channels, frames)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to load noise file %s: %s", noise_path, exc)
             if audio_len <= 0:
@@ -318,6 +363,7 @@ class AugmentationProcessor:
         noise_path: AnyPathT,
         snr_db_range: tuple[float, float],
         max_window_sec: float = 10.0,
+        mask_signal: bool = False,
     ) -> torch.Tensor:
         """Mix noise into audio signal at random SNR.
 
@@ -331,11 +377,14 @@ class AugmentationProcessor:
             Range of SNR values in dB to randomly sample from.
         max_window_sec : float, default=10.0
             Maximum window size in seconds for noise loading.
+        mask_signal : bool, default=False
+            If True, discard the original signal and return only the noise,
+            power-matched to the signal ("mask the signal, use only noise").
 
         Returns
         -------
         torch.Tensor
-            Audio tensor with noise mixed in.
+            Audio tensor with noise mixed in (or noise only if ``mask_signal``).
 
         """
         audio_len = wav.shape[-1]
@@ -345,10 +394,16 @@ class AugmentationProcessor:
         noise_wav = self._load_noise_segment(noise_path, audio_len, max_window_sec)
         noise_wav = self._match_audio_length(noise_wav, audio_len, audio_t.device)
 
-        # Apply SNR scaling
         signal_power = (audio_t**2).mean(dim=-1, keepdim=True)
         noise_power = (noise_wav**2).mean(dim=-1, keepdim=True)
 
+        if mask_signal:
+            # Replace the signal entirely with power-matched noise.
+            scale = torch.sqrt(signal_power / (noise_power + 1e-8))
+            masked = scale * noise_wav
+            return masked.squeeze(0) if wav.ndim == 1 else masked
+
+        # Apply SNR scaling
         snr_db = random.uniform(*snr_db_range)  # noqa: S311
         snr_linear = 10 ** (snr_db / 10)
         scale = torch.sqrt(signal_power / (noise_power * snr_linear + 1e-8))

--- a/avex/data/configs.py
+++ b/avex/data/configs.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import List, Literal, Optional, Tuple
 
 from alp_data import DatasetConfig
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
 
 
 class DatasetCollectionConfig(BaseModel):
@@ -89,6 +89,30 @@ class DatasetCollectionConfig(BaseModel):
         ),
     )
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("transformations", mode="after")
+    @classmethod
+    def _parse_global_transformations(cls, v: list | None) -> list | None:
+        """Convert raw dict transforms into typed alp_data transform configs.
+
+        The post-concatenation (global) transforms declared here are handed to
+        ``Dataset.apply_transformations``, which requires typed
+        ``RegisteredTransformConfigs`` (it reads ``cfg.type``). alp_data's own
+        ``DatasetConfig`` runs the equivalent conversion on its per-dataset
+        transforms; this collection-level field otherwise stays raw dicts and
+        crashes with ``KeyError: <class 'dict'>``. Mirror that conversion here.
+
+        Returns
+        -------
+        list | None
+            The transforms as typed ``RegisteredTransformConfigs`` (``None`` if empty).
+        """
+        if not v:
+            return None
+        from alp_data.transforms.registry import RegisteredTransformConfigs
+
+        adapter = TypeAdapter(RegisteredTransformConfigs)
+        return [adapter.validate_python(t) if isinstance(t, dict) else t for t in v]
 
     @model_validator(mode="after")
     def check_nonempty_datasets(self) -> "DatasetCollectionConfig":

--- a/avex/data/dataset.py
+++ b/avex/data/dataset.py
@@ -21,6 +21,9 @@ from alp_data import (
     dataset_from_config,
 )
 
+# Import for its side effect: registers the ``parse_json_list`` transform
+# (used to decode JSON-string multi-label columns, e.g. BirdSet ebird_code_multilabel).
+import avex.data.parse_json_list  # noqa: F401
 from avex.data import birdset_train_splits  # noqa: F401 - registers birdset_train
 
 # Temporary patch for AnimalSpeak for compatibility
@@ -187,6 +190,26 @@ def _build_datasets(
     label_map = {}
     num_classes = 0
 
+    def _val_test_transforms(transforms: list, fitted_label_map: dict) -> list:
+        """Pin the train-fitted label_map onto the label-building transform so val/test
+        reuse the SAME class->id mapping as train (otherwise each split rebuilds its own
+        map and the ids silently disagree with the model's output layer).
+
+        Returns
+        -------
+        list
+            The transforms with the train label_map injected into the label builder.
+        """
+        out = []
+        for t in transforms:
+            if getattr(t, "type", None) in ("labels_from_features", "label_from_feature") and (
+                "label_map" in getattr(type(t), "model_fields", {})
+            ):
+                out.append(t.model_copy(update={"label_map": fitted_label_map}))
+            else:
+                out.append(t)
+        return out
+
     # Handle multi-label case - check for labels_from_features transform metadata
     if "labels_from_features" in train_metadata:
         label_transform_metadata = train_metadata["labels_from_features"]
@@ -196,11 +219,11 @@ def _build_datasets(
         else:
             num_classes = len(label_map)
 
-        # Apply same transformations to val/test datasets to ensure consistency
+        # Apply same transformations to val/test, reusing the train-fitted label_map
         if val_ds and cfg.transformations:
-            val_ds.apply_transformations(cfg.transformations)
+            val_ds.apply_transformations(_val_test_transforms(cfg.transformations, label_map))
         if test_ds and cfg.transformations:
-            test_ds.apply_transformations(cfg.transformations)
+            test_ds.apply_transformations(_val_test_transforms(cfg.transformations, label_map))
 
     # Handle single-label case - check for label_from_feature transform metadata
     elif "label_from_feature" in train_metadata:
@@ -211,11 +234,11 @@ def _build_datasets(
         else:
             num_classes = len(label_map)
 
-        # Apply same transformations to val/test datasets to ensure consistency
+        # Apply same transformations to val/test, reusing the train-fitted label_map
         if val_ds and cfg.transformations:
-            val_ds.apply_transformations(cfg.transformations)
+            val_ds.apply_transformations(_val_test_transforms(cfg.transformations, label_map))
         if test_ds and cfg.transformations:
-            test_ds.apply_transformations(cfg.transformations)
+            test_ds.apply_transformations(_val_test_transforms(cfg.transformations, label_map))
 
     train_ds = AudioDataset(
         train_ds,

--- a/avex/data/parse_json_list.py
+++ b/avex/data/parse_json_list.py
@@ -1,0 +1,111 @@
+"""A dataset transform that parses a JSON-encoded string column into a real list column.
+
+Some datasets (e.g. BirdSet's ``ebird_code_multilabel``) store multi-label targets as
+JSON strings like ``'["amecro","daejun"]'`` or ``'[]'``. The multi-label label builder
+(``labels_from_features``) expects actual lists, otherwise it treats the whole JSON string
+as one opaque label and never drops the empty ``'[]'`` rows. This transform decodes those
+strings into lists so downstream multi-label handling (and no-label dropping) works.
+
+Registered at import time; import this module for the ``parse_json_list`` transform type to
+be available (wired in :pyfile:`avex/data/dataset.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+try:  # installed package is ``alp_data`` (renamed from ``esp_data``)
+    from alp_data.transforms import register_transform
+except ModuleNotFoundError:  # pragma: no cover - fallback for the old package name
+    from esp_data.transforms import register_transform
+
+logger = logging.getLogger("alp_data")
+
+
+def _polars_backend_cls() -> type:
+    try:
+        from alp_data.backends.polars_backend import PolarsBackend
+    except ModuleNotFoundError:  # pragma: no cover
+        from esp_data.backends.polars_backend import PolarsBackend
+    return PolarsBackend
+
+
+def _pandas_backend_cls() -> type:
+    try:
+        from alp_data.backends.pandas_backend import PandasBackend
+    except ModuleNotFoundError:  # pragma: no cover
+        from esp_data.backends.pandas_backend import PandasBackend
+    return PandasBackend
+
+
+class ParseJsonListConfig(BaseModel):
+    type: Literal["parse_json_list"]
+    feature: str
+
+
+class ParseJsonList:
+    """Decode a JSON-string column into a list column, in-place (by name)."""
+
+    def __init__(self, *, feature: str) -> None:
+        self.feature = feature
+
+    @classmethod
+    def from_config(cls, cfg: ParseJsonListConfig) -> "ParseJsonList":
+        return cls(**cfg.model_dump(exclude={"type"}))
+
+    def __call__(self, backend: Any) -> tuple[Any, dict]:  # noqa: ANN401
+        if "Polars" in type(backend).__name__:
+            return self._apply_polars(backend)
+        return self._apply_pandas(backend)
+
+    def _apply_polars(self, backend: Any) -> tuple[Any, dict]:  # noqa: ANN401
+        import polars as pl
+
+        PolarsBackend = _polars_backend_cls()
+        df = backend._df
+        if isinstance(df, pl.LazyFrame):
+            df = df.collect()
+        if self.feature not in df.columns:
+            logger.warning("ParseJsonList: column %r not present; pass-through", self.feature)
+            return backend, {"parsed": 0}
+        if df.schema[self.feature].base_type() == pl.List:
+            return backend, {"parsed": 0}
+        col = pl.col(self.feature)
+        decoded = (
+            pl.when(col.is_null() | (col.cast(pl.Utf8).str.strip_chars() == ""))
+            .then(pl.lit("[]"))
+            .otherwise(col.cast(pl.Utf8))
+            .str.json_decode(pl.List(pl.Utf8))
+            .alias(self.feature)
+        )
+        df_out = df.with_columns(decoded)
+        return PolarsBackend(df_out, streaming=False), {"parsed": len(df_out)}
+
+    def _apply_pandas(self, backend: Any) -> tuple[Any, dict]:  # noqa: ANN401
+        PandasBackend = _pandas_backend_cls()
+        df = backend._df
+        if self.feature not in df.columns:
+            logger.warning("ParseJsonList: column %r not present; pass-through", self.feature)
+            return backend, {"parsed": 0}
+        df = df.copy()
+
+        def _parse(v: Any) -> list:  # noqa: ANN401
+            if isinstance(v, list):
+                return v
+            if v is None or not isinstance(v, str) or v.strip() == "":
+                return []
+            try:
+                out = json.loads(v)
+                return out if isinstance(out, list) else [out]
+            except (ValueError, TypeError):
+                return []
+
+        df[self.feature] = df[self.feature].apply(_parse)
+        return PandasBackend(df, streaming=False), {"parsed": len(df)}
+
+
+register_transform(ParseJsonListConfig, ParseJsonList)

--- a/avex/data/parse_json_list.py
+++ b/avex/data/parse_json_list.py
@@ -43,6 +43,8 @@ def _pandas_backend_cls() -> type:
 
 
 class ParseJsonListConfig(BaseModel):
+    """Config for the ``parse_json_list`` transform (decode a JSON-string list column)."""
+
     type: Literal["parse_json_list"]
     feature: str
 

--- a/avex/evaluation/embedding_utils.py
+++ b/avex/evaluation/embedding_utils.py
@@ -222,20 +222,25 @@ def _extract_embeddings_streaming(
         inp = {"raw_wav": wav, "padding_mask": mask}
         sample_emb = model.extract_embeddings(inp, aggregation=aggregation)
 
-    # Handle single tensor, list of tensors, or dictionary
+    # Handle single tensor, list of tensors, or dictionary.
+    # Coerce each shape to a plain ``tuple`` of ints: downstream we build HDF5
+    # shapes via ``(None,) + embedding_dim`` / ``(total_samples,) + embedding_dim``.
+    # On torch>=2.11 ``tuple + torch.Size`` yields a ``torch.Size`` whose
+    # constructor rejects the ``None`` (unlimited) maxshape entry, so keep them
+    # as plain tuples (the in-memory path already does this).
     if isinstance(sample_emb, list):
         # For multi-layer, collect dimensions for each layer
         # Exclude batch dimension (0)
-        embedding_dims = [emb.shape[1:] for emb in sample_emb]
+        embedding_dims = [tuple(emb.shape[1:]) for emb in sample_emb]
         logger.info(f"Multi-layer embedding dimensions: {embedding_dims}")
     elif isinstance(sample_emb, dict):
         # For multi-layer dictionary, collect dimensions for each layer
         # Exclude batch dimension (0)
-        embedding_dims = [emb.shape[1:] for emb in sample_emb.values()]
+        embedding_dims = [tuple(emb.shape[1:]) for emb in sample_emb.values()]
         logger.info(f"Multi-layer embedding dimensions (dict): {embedding_dims}")
     else:
         # Single tensor case - still store as list for consistency
-        embedding_dims = [sample_emb.shape[1:]]  # Exclude batch dimension
+        embedding_dims = [tuple(sample_emb.shape[1:])]  # Exclude batch dimension
         logger.info(f"Single-layer embedding dimensions: {embedding_dims}")
 
     total_samples = len(dataloader.dataset)
@@ -382,7 +387,7 @@ def _create_and_fill_h5_datasets_hybrid(
     if sample_labels is None:
         raise ValueError("Labels not found in batch")
 
-    label_shape = sample_labels.shape[1:] if sample_labels.dim() > 1 else ()
+    label_shape = tuple(sample_labels.shape[1:]) if sample_labels.dim() > 1 else ()
     label_dtype = sample_labels.dtype
 
     logger.info(f"Sample labels info: shape={sample_labels.shape}, dims={sample_labels.dim()}, dtype={label_dtype}")

--- a/avex/models/beats_model.py
+++ b/avex/models/beats_model.py
@@ -259,6 +259,9 @@ class Model(ModelBase):
 
         # features: (B, T', D)
         # frame_padding: (B, T') or None
+        # Stash the frame-level padding mask so extract_embeddings() can do masked
+        # pooling over the same temporal grid (all encoder layers share T').
+        self._last_frame_padding = frame_padding
 
         if self._return_features_only:
             return features
@@ -405,10 +408,32 @@ class Model(ModelBase):
                         # Already in correct shape
                         pass
                     elif embeddings[i].dim() == 3:
+                        # Frame-level padding mask from the last forward pass (B, T').
+                        # Apply masked pooling so padded frames don't pollute the
+                        # aggregate — matches forward()'s masked mean-pooling.
+                        fp = getattr(self, "_last_frame_padding", None)
+                        use_mask = (
+                            fp is not None
+                            and fp.dim() == 2
+                            and fp.shape[0] == embeddings[i].shape[0]
+                            and fp.shape[1] == embeddings[i].shape[1]
+                            and bool(fp.any())
+                        )
                         if aggregation == "mean":
-                            embeddings[i] = torch.mean(embeddings[i], dim=1)
+                            if use_mask:
+                                masked = embeddings[i].clone()
+                                masked[fp] = 0.0
+                                valid = (~fp).sum(dim=1, keepdim=True).clamp(min=1)
+                                embeddings[i] = masked.sum(dim=1) / valid
+                            else:
+                                embeddings[i] = torch.mean(embeddings[i], dim=1)
                         elif aggregation == "max":
-                            embeddings[i] = torch.max(embeddings[i], dim=1)[0]  # max returns (values, indices)
+                            if use_mask:
+                                masked = embeddings[i].clone()
+                                masked[fp] = float("-inf")
+                                embeddings[i] = masked.max(dim=1)[0]
+                            else:
+                                embeddings[i] = torch.max(embeddings[i], dim=1)[0]  # max returns (values, indices)
                         elif aggregation == "cls_token":
                             embeddings[i] = embeddings[i][:, 0, :]
                         else:

--- a/avex/models/eat_hf.py
+++ b/avex/models/eat_hf.py
@@ -40,6 +40,33 @@ from avex.utils.utils import universal_torch_load
 logger = logging.getLogger(__name__)
 
 
+def _rename_eat_key(key: str) -> str:
+    """Rename fairseq/data2vec-multi EAT keys to the HuggingFace naming convention.
+
+    The published EAT checkpoints store the input stage under
+    ``modality_encoders.IMAGE.*`` (data2vec-multi layout), while the HF model
+    flattens it (``model.local_encoder.proj``, ``model.extra_tokens``,
+    ``model.fixed_positional_encoder.positions``, ``model.pre_norm``). Everything
+    else is placed under ``model.*``.
+
+    Args:
+        key: Original fairseq key name
+
+    Returns:
+        str: Renamed key for the HuggingFace model (``model.*``).
+    """
+    if key == "modality_encoders.IMAGE.context_encoder.norm.weight":
+        return "model.pre_norm.weight"
+    if key == "modality_encoders.IMAGE.context_encoder.norm.bias":
+        return "model.pre_norm.bias"
+    img_prefix = "modality_encoders.IMAGE."
+    if key.startswith(img_prefix):
+        key = "model." + key[len(img_prefix) :]
+    elif not key.startswith("model."):
+        key = "model." + key
+    return key
+
+
 def load_fairseq_weights(model: AutoModel, weights_path: str) -> None:
     """Load fairseq weights into HuggingFace model.
 
@@ -50,28 +77,7 @@ def load_fairseq_weights(model: AutoModel, weights_path: str) -> None:
         model: HuggingFace model to load weights into
         weights_path: Path to the fairseq checkpoint file
     """
-
-    def _rename_key(key: str) -> str:
-        """Rename fairseq keys to match HuggingFace naming convention.
-
-        Args:
-            key: Original fairseq key name
-
-        Returns:
-            str: Renamed key for HuggingFace model
-        """
-        if key == "modality_encoders.IMAGE.context_encoder.norm.weight":
-            # return "model.fc_norm.weight"
-            return "model.pre_norm.weight"
-        if key == "modality_encoders.IMAGE.context_encoder.norm.bias":
-            # return "model.fc_norm.bias"
-            return "model.pre_norm.bias"
-        img_prefix = "modality_encoders.IMAGE."
-        if key.startswith(img_prefix):
-            key = "model." + key[len(img_prefix) :]
-        elif not key.startswith("model."):
-            key = "model." + key
-        return key
+    _rename_key = _rename_eat_key
 
     alt_model = universal_torch_load(weights_path)["model"]
 
@@ -216,6 +222,35 @@ class EATHFModel(ModelBase):
         #  Pre-discover MLP layers for efficient hook management        #
         # -------------------------------------------------------------- #
         # MLP layers will be discovered in _discover_embedding_layers override
+
+    def remap_checkpoint_state_dict(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Map a fairseq/data2vec-multi EAT checkpoint onto this wrapper's keys.
+
+        The published EAT checkpoints (e.g. ``esp-aves2-eat-all``) ship bare
+        ``blocks.*`` transformer keys plus an input stage under
+        ``modality_encoders.IMAGE.*`` (patch conv, CLS/extra token, positional
+        encoding, input norm), and a pretraining-only ``...decoder.*`` head. The
+        generic prefix reconciliation only prepends ``backbone.model.``, which
+        matches the blocks but leaves the input stage under the wrong names (so 6
+        params silently stay at their HF-init values). This applies the same
+        renaming as :func:`load_fairseq_weights` and prepends ``backbone.``, then
+        keeps only keys that exist in the model (dropping the decoder).
+
+        Args:
+            state_dict: Raw checkpoint state dict (fairseq/data2vec key names).
+
+        Returns:
+            A state dict keyed to this model's ``backbone.model.*`` parameters.
+        """
+        target = set(self.state_dict().keys())
+        out: dict[str, Any] = {}
+        for k, v in state_dict.items():
+            if k.startswith("_ema"):
+                continue
+            new_k = "backbone." + _rename_eat_key(k)
+            if new_k in target:
+                out[new_k] = v
+        return out
 
     def _discover_embedding_layers(self) -> None:
         """Discover and cache only the EAT layers that are useful for embeddings.

--- a/avex/models/utils/load.py
+++ b/avex/models/utils/load.py
@@ -559,7 +559,7 @@ def _load_checkpoint(model: object, checkpoint_path: str, device: str, keep_clas
     def _overlap(sd: dict) -> int:
         return len(set(sd) & _tk)
 
-    if state_dict and _overlap(state_dict) == 0:
+    if state_dict and _tk and _overlap(state_dict) == 0:
         ck0 = min(state_dict, key=len)  # shortest checkpoint key
         mk0 = min(_tk, key=len)  # shortest model key
         # (a) model has an extra leading prefix the checkpoint lacks -> prepend it

--- a/avex/models/utils/load.py
+++ b/avex/models/utils/load.py
@@ -560,6 +560,18 @@ def _load_checkpoint(model: object, checkpoint_path: str, device: str, keep_clas
         return len(set(sd) & _tk)
 
     if state_dict and _tk and _overlap(state_dict) == 0:
+        candidates: list[tuple[str, dict]] = []
+
+        # (0) model-specific remap hook — e.g. eat_hf maps a fairseq/data2vec
+        # checkpoint's `modality_encoders.IMAGE.*` input stage onto its flattened
+        # `backbone.model.*` keys, which a plain prefix add can never recover.
+        remap = getattr(model, "remap_checkpoint_state_dict", None)
+        if callable(remap):
+            try:
+                candidates.append(("model-specific remap", remap(state_dict)))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("model remap_checkpoint_state_dict failed: %s", exc)
+
         ck0 = min(state_dict, key=len)  # shortest checkpoint key
         mk0 = min(_tk, key=len)  # shortest model key
         # (a) model has an extra leading prefix the checkpoint lacks -> prepend it
@@ -568,16 +580,18 @@ def _load_checkpoint(model: object, checkpoint_path: str, device: str, keep_clas
         strip_cands = [k[: -len(mk0)] for k in state_dict if k.endswith("." + mk0)]
         if add_cands:
             pfx = add_cands[0]
-            cand = {f"{pfx}{k}": v for k, v in state_dict.items()}
-            if _overlap(cand) > 0:
-                state_dict = cand
-                logger.info("Added '%s' prefix to checkpoint keys to match model", pfx)
-        elif strip_cands:
+            candidates.append((f"add '{pfx}' prefix", {f"{pfx}{k}": v for k, v in state_dict.items()}))
+        if strip_cands:
             pfx = strip_cands[0]
-            cand = {k[len(pfx) :]: v for k, v in state_dict.items() if k.startswith(pfx)}
-            if _overlap(cand) > 0:
-                state_dict = cand
-                logger.info("Removed '%s' prefix from checkpoint keys to match model", pfx)
+            candidates.append(
+                (f"strip '{pfx}' prefix", {k[len(pfx) :]: v for k, v in state_dict.items() if k.startswith(pfx)})
+            )
+
+        # Pick the reconciliation that recovers the most parameters.
+        best = max(candidates, key=lambda c: _overlap(c[1]), default=None)
+        if best is not None and _overlap(best[1]) > 0:
+            state_dict = best[1]
+            logger.info("Reconciled checkpoint keys via %s (%d/%d overlap)", best[0], _overlap(best[1]), len(_tk))
 
     # Load weights
     result = model.load_state_dict(state_dict, strict=False)

--- a/avex/models/utils/load.py
+++ b/avex/models/utils/load.py
@@ -550,16 +550,34 @@ def _load_checkpoint(model: object, checkpoint_path: str, device: str, keep_clas
         drop_model_prefix=not target_has_model_prefix,
     )
 
-    # Adapt backbone. prefix when checkpoint and model disagree
-    target_has_backbone = any(k.startswith("backbone.") for k in target_keys)
-    ckpt_has_backbone = any(k.startswith("backbone.") for k in state_dict)
+    # Reconcile a leading-prefix mismatch between checkpoint and model keys.
+    # Handles a single `backbone.` level (BEATs) AND deeper wrappers, e.g. eat_hf
+    # nests EAT under `backbone.model.` while the published checkpoint ships bare
+    # `blocks.*` keys -> would otherwise be 0 matches.
+    _tk = set(target_keys)
 
-    if target_has_backbone and not ckpt_has_backbone:
-        state_dict = {f"backbone.{k}": v for k, v in state_dict.items()}
-        logger.info("Added 'backbone.' prefix to checkpoint keys to match model")
-    elif not target_has_backbone and ckpt_has_backbone:
-        state_dict = {k.removeprefix("backbone."): v for k, v in state_dict.items()}
-        logger.info("Removed 'backbone.' prefix from checkpoint keys to match model")
+    def _overlap(sd: dict) -> int:
+        return len(set(sd) & _tk)
+
+    if state_dict and _overlap(state_dict) == 0:
+        ck0 = min(state_dict, key=len)  # shortest checkpoint key
+        mk0 = min(_tk, key=len)  # shortest model key
+        # (a) model has an extra leading prefix the checkpoint lacks -> prepend it
+        add_cands = [k[: -len(ck0)] for k in _tk if k.endswith("." + ck0)]
+        # (b) checkpoint has an extra leading prefix the model lacks -> strip it
+        strip_cands = [k[: -len(mk0)] for k in state_dict if k.endswith("." + mk0)]
+        if add_cands:
+            pfx = add_cands[0]
+            cand = {f"{pfx}{k}": v for k, v in state_dict.items()}
+            if _overlap(cand) > 0:
+                state_dict = cand
+                logger.info("Added '%s' prefix to checkpoint keys to match model", pfx)
+        elif strip_cands:
+            pfx = strip_cands[0]
+            cand = {k[len(pfx) :]: v for k, v in state_dict.items() if k.startswith(pfx)}
+            if _overlap(cand) > 0:
+                state_dict = cand
+                logger.info("Removed '%s' prefix from checkpoint keys to match model", pfx)
 
     # Load weights
     result = model.load_state_dict(state_dict, strict=False)

--- a/avex/run_evaluate.py
+++ b/avex/run_evaluate.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional
 import pandas as pd
 import torch
 from alp_data import DatasetConfig
-from alp_data.io import AnyPathT, anypath, exists
+from alp_data.io import AnyPathT, anypath
 from alp_data.io.paths import PureCloudPath
 
 # Import avex modules
@@ -52,13 +52,14 @@ from avex.evaluation.retrieval import (
     eval_retrieval_cross_set,
 )
 from avex.models.utils.factory import build_model_from_spec
+from avex.models.utils.load import _load_checkpoint
 from avex.utils import ExperimentLogger
 from avex.utils.experiment_tracking import (
     create_experiment_summary_csvs,
     get_or_create_experiment_metadata,
     save_evaluation_metadata,
 )
-from avex.utils.utils import _embedding_cache_matches, _process_state_dict, universal_torch_load
+from avex.utils.utils import _embedding_cache_matches
 
 logger = logging.getLogger("run_finetune")
 
@@ -461,27 +462,23 @@ def run_experiment(
             base_model = cached_model
         else:
             logger.info("Loading model (cache miss or first dataset)")
-            # Build backbone-only model; classifier heads are handled by probes
+            # Build backbone-only model; classifier heads are handled by probes.
+            # Force feature-only construction: BEATs auto-falls-back when num_classes
+            # is None, but eat_hf raises ("num_classes must be > 0 …") unless
+            # return_features_only is set explicitly.
             base_model = build_model_from_spec(
                 run_cfg.model_spec,
                 device=str(device),
+                return_features_only=True,
             ).to(device)
 
             if experiment_cfg.checkpoint_path:
-                ckpt_path = anypath(experiment_cfg.checkpoint_path)
-                if not exists(ckpt_path):
-                    raise FileNotFoundError(f"Checkpoint not found: {ckpt_path}")
-
-                # fs = filesystem_from_path(ckpt_path)
-                # with fs.open(ckpt_path, "rb") as f:
-                state = universal_torch_load(ckpt_path, map_location=device)
-                # state = torch.load(f, map_location=device)
-
-                if "model_state_dict" in state:
-                    state = _process_state_dict(state)
-
-                base_model.load_state_dict(state, strict=False)
-                logger.info("Loaded checkpoint from %s", ckpt_path)
+                # Use the prefix-aware loader (adapts a bare BEATs state_dict to the
+                # wrapper's "backbone." keys, strips "model."/classifier as needed).
+                # A naive base_model.load_state_dict(strict=False) silently matches 0
+                # keys for flat checkpoints (e.g. NatureLM's audio_encoder/beats.pt),
+                # leaving the backbone randomly initialised.
+                _load_checkpoint(base_model, str(experiment_cfg.checkpoint_path), str(device))
 
         # Note: Base model parameter freezing/counting handled by
         # build_probe_from_config() function

--- a/configs/data_configs/benchmark_beans_gcs.yml
+++ b/configs/data_configs/benchmark_beans_gcs.yml
@@ -1,0 +1,291 @@
+benchmark_name: "bioacoustic_benchmark"
+
+evaluation_sets:
+  # Classification Tasks
+  - name: "dog_classification"
+    train: &dogs_base
+      dataset_name: beans
+      split: dogs_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 10
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {'Farley': 0, 'Freid': 1, 'Keri': 2, 'Louie': 3, 'Luke': 4, 'Mac': 5, 'Roodie': 6, 'Rudy': 7, 'Siggy': 8, 'Zoe': 9}
+      sample_rate: 16000
+    validation:
+      <<: *dogs_base
+      split: dogs_validation
+    test:
+      <<: *dogs_base
+      split: dogs_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+  - name: "bat_classification"
+    train: &bats_base
+      dataset_name: beans
+      split: egyptian_fruit_bats_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {111: 0, 210: 1, 211: 2, 215: 3, 216: 4, 220: 5, 226: 6, 228: 7, 230: 8, 231: 9}
+      sample_rate: 16000
+    validation:
+      <<: *bats_base
+      split: egyptian_fruit_bats_validation
+    test:
+      <<: *bats_base
+      split: egyptian_fruit_bats_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+  - name: "mosquito_classification"
+    train: &mosquito_base
+      dataset_name: beans
+      split: humbugdb_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 3
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {'ae aegypti': 0, 'an arabiensis': 1, 'an dirus': 2, 'an funestus sl': 3, 'an funestus ss': 4, 'an gambiae ss': 5, 'an harrisoni': 6, 'an maculatus': 7, 'an squamosus': 8, 'culex pipiens complex': 9, 'culex quinquefasciatus': 10, 'ma uniformis': 11, 'non-mosquito': 12, 'others': 13}
+      sample_rate: 16000
+    validation:
+      <<: *mosquito_base
+      split: humbugdb_validation
+    test:
+      <<: *mosquito_base
+      split: humbugdb_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+  - name: "bird_classification"
+    train: &bird_base
+      dataset_name: beans
+      split: cbi_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 10
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {'aldfly': 0, 'ameavo': 1, 'amebit': 2, 'amecro': 3, 'amegfi': 4, 'amekes': 5, 'amepip': 6, 'amered': 7, 'amerob': 8, 'amewig': 9, 'amewoo': 10, 'amtspa': 11, 'annhum': 12, 'astfly': 13, 'baisan': 14, 'baleag': 15, 'balori': 16, 'banswa': 17, 'barswa': 18, 'bawwar': 19, 'belkin1': 20, 'belspa2': 21, 'bewwre': 22, 'bkbcuc': 23, 'bkbmag1': 24, 'bkbwar': 25, 'bkcchi': 26, 'bkchum': 27, 'bkhgro': 28, 'bkpwar': 29, 'bktspa': 30, 'blkpho': 31, 'blugrb1': 32, 'blujay': 33, 'bnhcow': 34, 'boboli': 35, 'bongul': 36, 'brdowl': 37, 'brebla': 38, 'brespa': 39, 'brncre': 40, 'brnthr': 41, 'brthum': 42, 'brwhaw': 43, 'btbwar': 44, 'btnwar': 45, 'btywar': 46, 'buffle': 47, 'buggna': 48, 'buhvir': 49, 'bulori': 50, 'bushti': 51, 'buwtea': 52, 'buwwar': 53, 'cacwre': 54, 'calgul': 55, 'calqua': 56, 'camwar': 57, 'cangoo': 58, 'canwar': 59, 'canwre': 60, 'carwre': 61, 'casfin': 62, 'caster1': 63, 'casvir': 64, 'cedwax': 65, 'chispa': 66, 'chiswi': 67, 'chswar': 68, 'chukar': 69, 'clanut': 70, 'cliswa': 71, 'comgol': 72, 'comgra': 73, 'comloo': 74, 'commer': 75, 'comnig': 76, 'comrav': 77, 'comred': 78, 'comter': 79, 'comyel': 80, 'coohaw': 81, 'coshum': 82, 'cowscj1': 83, 'daejun': 84, 'doccor': 85, 'dowwoo': 86, 'dusfly': 87, 'eargre': 88, 'easblu': 89, 'easkin': 90, 'easmea': 91, 'easpho': 92, 'eastow': 93, 'eawpew': 94, 'eucdov': 95, 'eursta': 96, 'evegro': 97, 'fiespa': 98, 'fiscro': 99, 'foxspa': 100, 'gadwal': 101, 'gcrfin': 102, 'gnttow': 103, 'gnwtea': 104, 'gockin': 105, 'gocspa': 106, 'goleag': 107, 'grbher3': 108, 'grcfly': 109, 'greegr': 110, 'greroa': 111, 'greyel': 112, 'grhowl': 113, 'grnher': 114, 'grtgra': 115, 'grycat': 116, 'gryfly': 117, 'haiwoo': 118, 'hamfly': 119, 'hergul': 120, 'herthr': 121, 'hoomer': 122, 'hoowar': 123, 'horgre': 124, 'horlar': 125, 'houfin': 126, 'houspa': 127, 'houwre': 128, 'indbun': 129, 'juntit1': 130, 'killde': 131, 'labwoo': 132, 'larspa': 133, 'lazbun': 134, 'leabit': 135, 'leafly': 136, 'leasan': 137, 'lecthr': 138, 'lesgol': 139, 'lesnig': 140, 'lesyel': 141, 'lewwoo': 142, 'linspa': 143, 'lobcur': 144, 'lobdow': 145, 'logshr': 146, 'lotduc': 147, 'louwat': 148, 'macwar': 149, 'magwar': 150, 'mallar3': 151, 'marwre': 152, 'merlin': 153, 'moublu': 154, 'mouchi': 155, 'moudov': 156, 'norcar': 157, 'norfli': 158, 'norhar2': 159, 'normoc': 160, 'norpar': 161, 'norpin': 162, 'norsho': 163, 'norwat': 164, 'nrwswa': 165, 'nutwoo': 166, 'olsfly': 167, 'orcwar': 168, 'osprey': 169, 'ovenbi1': 170, 'palwar': 171, 'pasfly': 172, 'pecsan': 173, 'perfal': 174, 'phaino': 175, 'pibgre': 176, 'pilwoo': 177, 'pingro': 178, 'pinjay': 179, 'pinsis': 180, 'pinwar': 181, 'plsvir': 182, 'prawar': 183, 'purfin': 184, 'pygnut': 185, 'rebmer': 186, 'rebnut': 187, 'rebsap': 188, 'rebwoo': 189, 'redcro': 190, 'redhea': 191, 'reevir1': 192, 'renpha': 193, 'reshaw': 194, 'rethaw': 195, 'rewbla': 196, 'ribgul': 197, 'rinduc': 198, 'robgro': 199, 'rocpig': 200, 'rocwre': 201, 'rthhum': 202, 'ruckin': 203, 'rudduc': 204, 'rufgro': 205, 'rufhum': 206, 'rusbla': 207, 'sagspa1': 208, 'sagthr': 209, 'savspa': 210, 'saypho': 211, 'scatan': 212, 'scoori': 213, 'semplo': 214, 'semsan': 215, 'sheowl': 216, 'shshaw': 217, 'snobun': 218, 'snogoo': 219, 'solsan': 220, 'sonspa': 221, 'sora': 222, 'sposan': 223, 'spotow': 224, 'stejay': 225, 'swahaw': 226, 'swaspa': 227, 'swathr': 228, 'treswa': 229, 'truswa': 230, 'tuftit': 231, 'tunswa': 232, 'veery': 233, 'vesspa': 234, 'vigswa': 235, 'warvir': 236, 'wesblu': 237, 'wesgre': 238, 'weskin': 239, 'wesmea': 240, 'wessan': 241, 'westan': 242, 'wewpew': 243, 'whbnut': 244, 'whcspa': 245, 'whfibi': 246, 'whtspa': 247, 'whtswi': 248, 'wilfly': 249, 'wilsni1': 250, 'wiltur': 251, 'winwre3': 252, 'wlswar': 253, 'wooduc': 254, 'wooscj2': 255, 'woothr': 256, 'y00475': 257, 'yebfly': 258, 'yebsap': 259, 'yehbla': 260, 'yelwar': 261, 'yerwar': 262, 'yetvir': 263}
+      sample_rate: 16000
+    validation:
+      <<: *bird_base
+      split: cbi_validation
+    test:
+      <<: *bird_base
+      split: cbi_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+
+  - name: "marine_mammal_classification"
+    train: &watkins_base
+      dataset_name: beans
+      split: watkins_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 3
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {'Atlantic_Spotted_Dolphin': 0, 'Bearded_Seal': 1, 'Beluga,_White_Whale': 2, 'Bottlenose_Dolphin': 3, 'Bowhead_Whale': 4, 'Clymene_Dolphin': 5, 'Common_Dolphin': 6, 'False_Killer_Whale': 7, 'Fin,_Finback_Whale': 8, 'Frasers_Dolphin': 9, 'Grampus,_Rissos_Dolphin': 10, 'Harp_Seal': 11, 'Humpback_Whale': 12, 'Killer_Whale': 13, 'Leopard_Seal': 14, 'Long-Finned_Pilot_Whale': 15, 'Melon_Headed_Whale': 16, 'Minke_Whale': 17, 'Narwhal': 18, 'Northern_Right_Whale': 19, 'Pantropical_Spotted_Dolphin': 20, 'Ross_Seal': 21, 'Rough-Toothed_Dolphin': 22, 'Short-Finned_Pacific_Pilot_Whale': 23, 'Southern_Right_Whale': 24, 'Sperm_Whale': 25, 'Spinner_Dolphin': 26, 'Striped_Dolphin': 27, 'Walrus': 28, 'White-beaked_Dolphin': 29, 'White-sided_Dolphin': 30}
+      sample_rate: 16000
+    validation:
+      <<: *watkins_base
+      split: watkins_validation
+    test:
+      <<: *watkins_base
+      split: watkins_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+  - name: "esc50_classification"
+    train: &esc50_base
+      dataset_name: beans
+      split: esc50_train
+      type: classification
+      label_column: label
+      audio_path_col: path
+      multi_label: false
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        - type: label_from_feature
+          feature: label
+          override: true
+          label_map: {'airplane': 0, 'breathing': 1, 'brushing_teeth': 2, 'can_opening': 3, 'car_horn': 4, 'cat': 5, 'chainsaw': 6, 'chirping_birds': 7, 'church_bells': 8, 'clapping': 9, 'clock_alarm': 10, 'clock_tick': 11, 'coughing': 12, 'cow': 13, 'crackling_fire': 14, 'crickets': 15, 'crow': 16, 'crying_baby': 17, 'dog': 18, 'door_wood_creaks': 19, 'door_wood_knock': 20, 'drinking_sipping': 21, 'engine': 22, 'fireworks': 23, 'footsteps': 24, 'frog': 25, 'glass_breaking': 26, 'hand_saw': 27, 'helicopter': 28, 'hen': 29, 'insects': 30, 'keyboard_typing': 31, 'laughing': 32, 'mouse_click': 33, 'pig': 34, 'pouring_water': 35, 'rain': 36, 'rooster': 37, 'sea_waves': 38, 'sheep': 39, 'siren': 40, 'sneezing': 41, 'snoring': 42, 'thunderstorm': 43, 'toilet_flush': 44, 'train': 45, 'vacuum_cleaner': 46, 'washing_machine': 47, 'water_drops': 48, 'wind': 49}
+      sample_rate: 16000
+    validation:
+      <<: *esc50_base
+      split: esc50_validation
+    test:
+      <<: *esc50_base
+      split: esc50_test
+    metrics: [accuracy, balanced_accuracy, clustering_ari, clustering_nmi]
+
+  # Detection Tasks
+  - name: "hiceas_detection"
+    train: &hiceas_base
+      dataset_name: beans
+      split: hiceas_train
+      type: detection
+      label_column: labels_as_list
+      audio_path_col: path
+      multi_label: true
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        # Repair train rows where labels_as_list is [] or [null] but label is in answer
+        - type: fill_labels_from_answer
+          source: answer
+          target: labels_as_list
+        # Convert list labels to multi-label format
+        - type: labels_from_features
+          features:
+            - labels_as_list
+          override: true
+          label_map: {"Minke whale": 0}
+      sample_rate: 16000
+    validation:
+      <<: *hiceas_base
+      split: hiceas_validation
+    test:
+      <<: *hiceas_base
+      split: hiceas_test
+    metrics: [mAP]
+
+  - name: "hainan_gibbons_detection"
+    train: &gibbons_base
+      dataset_name: beans
+      split: hainan_gibbons_train
+      type: detection
+      label_column: labels_as_list
+      audio_path_col: path
+      multi_label: true
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        # Repair train rows where labels_as_list is [] or [null] but label is in answer
+        - type: fill_labels_from_answer
+          source: answer
+          target: labels_as_list
+        # Convert list labels to multi-label format
+        - type: labels_from_features
+          features:
+            - labels_as_list
+          override: true
+          label_map: {'Gibbon duet': 0, 'Multiple pulse gibbon call': 1, 'Single pulse gibbon call': 2}
+      sample_rate: 16000
+    validation:
+      <<: *gibbons_base
+      split: hainan_gibbons_validation
+    test:
+      <<: *gibbons_base
+      split: hainan_gibbons_test
+    metrics: [mAP]
+
+  - name: "dcase_detection"
+    train: &dcase_base
+      dataset_name: beans
+      split: dcase_train
+      type: detection
+      label_column: labels_as_list
+      audio_path_col: path
+      multi_label: true
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        - type: labels_from_features
+          features:
+            - labels_as_list
+          override: true
+          label_map: {'American Redstart': 0, 'Bay-breasted Warbler': 1, 'Black-throated Blue Warbler': 2, 'Chipping Sparrow': 3, 'Common Yellowthroat': 4, 'Gray-cheeked Thrush': 5, 'Hyena giggle': 6, 'Hyena groan and moo': 7, 'Hyena squitter': 8, 'Jackdaw call': 9, 'Meerkat close call': 10, 'Meerkat short note': 11, 'Other Animal': 12, 'Ovenbird': 13, 'Rose-breasted Grosbeak': 14, 'Savannah Sparrow': 15, "Swainson's Thrush": 16, 'White-throated Sparrow': 17}
+      sample_rate: 16000
+    validation:
+      <<: *dcase_base
+      split: dcase_validation
+    test:
+      <<: *dcase_base
+      split: dcase_test
+    metrics: [mAP]
+
+  - name: "enabirds_detection"
+    train: &enabirds_base
+      dataset_name: beans
+      split: enabirds_train
+      type: detection
+      label_column: labels_as_list
+      audio_path_col: path
+      multi_label: true
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        - type: fill_labels_from_answer
+          source: answer
+          target: labels_as_list
+        - type: labels_from_features
+          features:
+            - labels_as_list
+          override: true
+          label_map: {'American Crow': 0, 'American Goldfinch': 1, 'American Redstart': 2, 'American Robin': 3, 'Black-and-white Warbler': 4, 'Black-capped Chickadee': 5, 'Black-throated Blue Warbler': 6, 'Black-throated Green Warbler': 7, 'Blue Jay': 8, 'Blue-gray Gnatcatcher': 9, 'Blue-headed Vireo': 10, 'Brown-headed Cowbird': 11, 'Carolina Wren': 12, 'Common Yellowthroat': 13, 'Eastern Towhee': 14, 'Hermit Thrush': 15, 'Hooded Warbler': 16, "Kirtland's Warbler": 17, 'Louisiana Waterthrush': 18, 'None': 19, 'Northern Cardinal': 20, 'Northern Flicker': 21, 'Other Bird': 22, 'Ovenbird': 23, 'Red-bellied Woodpecker': 24, 'Red-eyed Vireo': 25, 'Rose-breasted Grosbeak': 26, 'Ruby-crowned Kinglet': 27, 'Scarlet Tanager': 28, "Swainson's Thrush": 29, 'Tufted Titmouse': 30, 'White-breasted Nuthatch': 31, 'Wild Turkey': 32, 'Wood Thrush': 33, 'Yellow-billed Cuckoo': 34}
+      sample_rate: 16000
+
+    validation:
+      <<: *enabirds_base
+      split: enabirds_validation
+    test:
+      <<: *enabirds_base
+      split: enabirds_test
+    metrics: [mAP]
+
+  - name: "rfcx_detection"
+    train: &rfcx_base
+      dataset_name: beans
+      split: rfcx_train
+      type: detection
+      label_column: labels_as_list
+      audio_path_col: path
+      multi_label: true
+      label_type: supervised
+      audio_max_length_seconds: 5
+      transformations:
+        - type: fill_labels_from_answer
+          source: answer
+          target: labels_as_list
+        - type: labels_from_features
+          features:
+            - labels_as_list
+          override: true
+          label_map: {'Bananaquit': 0, 'Black-whiskered vireo': 1, 'Bronze coqui': 2, 'Common coqui': 3, 'Cricket coqui': 4, 'Dwarf coqui': 5, 'Elfin woods warbler': 6, 'Grass coqui': 7, "Hedrick's coqui": 8, 'Locust coqui': 9, 'Melodius coqui': 10, 'Mountain Coqui': 11, 'Pearly-eyed thrasher': 12, 'Puerto Rican bullfinch': 13, 'Puerto Rican lizard cuckoo': 14, 'Puerto Rican owl': 15, 'Puerto Rican spindalis': 16, 'Puerto Rican tanager': 17, 'Puerto Rican tody': 18, 'Puerto Rican woodpecker': 19, 'Red-eyed coqui': 20, 'Red-legged thrush': 21, 'Scaly-naped pigeon': 22, 'White-lipped Frog': 23}
+      sample_rate: 16000
+    validation:
+      <<: *rfcx_base
+      split: rfcx_validation
+    test:
+      <<: *rfcx_base
+      split: rfcx_test
+    metrics: [mAP]

--- a/configs/data_configs/icassp_2026/data_audioset_xeno_inat.yml
+++ b/configs/data_configs/icassp_2026/data_audioset_xeno_inat.yml
@@ -1,0 +1,69 @@
+# ICASSP 2026: supervised post-training corpus = AudioSet + Xeno-canto + iNaturalist,
+# using the now-SEPARATE alp-data datasets (previously bundled as `animalspeak`).
+#
+# Unified multi-label space (Option B: unify AFTER concatenation):
+#   - AudioSet: native `labels` is a JSON STRING (e.g. '["Music","Speech"]'); parse it into a
+#     real list per-dataset with `parse_json_list` so individual AudioSet classes become labels
+#     (otherwise each full combo string becomes one opaque label -> ~40k junk classes).
+#   - Xeno-canto / iNaturalist: native scalar `canonical_name` (species string).
+#   - Global `labels_from_features features: [labels, canonical_name]` builds ONE joint map over
+#     {AudioSet classes} U {species}. Each column stays single-typed after soft concat
+#     (`labels` = List, null on species rows; `canonical_name` = str, null on AudioSet rows),
+#     so no mixed-dtype column. A species shared by iNat and Xeno is the SAME string -> ONE id.
+# Registered dataset names: `audioset`, `xeno-canto` (hyphen!), `inaturalist`.
+
+train_datasets:
+  - dataset_name: audioset
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    data_root: gs://esp-ml-datasets/audioset/v0.1.0/raw/
+    transformations:
+      - type: parse_json_list
+        feature: labels
+
+  - dataset_name: xeno-canto
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    # native label column: canonical_name (species)
+
+  - dataset_name: inaturalist
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    # native label column: canonical_name (species)
+
+val_datasets:
+  # AudioSet must be present in val too, otherwise the `labels` column doesn't exist and
+  # the joint labels_from_features (features: [labels, canonical_name]) errors on val.
+  - dataset_name: audioset
+    split: validation
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    data_root: gs://esp-ml-datasets/audioset/v0.1.0/raw/
+    transformations:
+      - type: parse_json_list
+        feature: labels
+  - dataset_name: xeno-canto
+    split: validation
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+  - dataset_name: inaturalist
+    split: val
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+
+concatenate_train: true
+concatenate_val: true
+concatenate_method: soft
+
+# Global transforms after concatenation: unified joint label space + dedup.
+transformations:
+  - type: labels_from_features
+    features: [labels, canonical_name]
+    output_feature: label
+    override: true
+    allow_missing_labels: false     # drop rows that end up with no label
+  - type: deduplicate
+    subset: ['local_path']

--- a/configs/data_configs/icassp_2026/data_audioset_xeno_inat_smoke.yml
+++ b/configs/data_configs/icassp_2026/data_audioset_xeno_inat_smoke.yml
@@ -1,0 +1,61 @@
+# SMOKE variant of data_audioset_xeno_inat.yml: tiny subsets so a single-GPU training
+# run builds + steps quickly. Same label-unification logic (parse_json_list on AudioSet,
+# joint labels_from_features over [labels, canonical_name]).
+train_datasets:
+  - dataset_name: audioset
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.004
+    data_root: gs://esp-ml-datasets/audioset/v0.1.0/raw/
+    transformations:
+      - type: parse_json_list
+        feature: labels
+
+  - dataset_name: xeno-canto
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.02
+
+  - dataset_name: inaturalist
+    split: train
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.05
+
+val_datasets:
+  # AudioSet must be present in val too, otherwise the `labels` column doesn't exist and
+  # the joint labels_from_features (features: [labels, canonical_name]) errors on val.
+  - dataset_name: audioset
+    split: validation
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.02
+    data_root: gs://esp-ml-datasets/audioset/v0.1.0/raw/
+    transformations:
+      - type: parse_json_list
+        feature: labels
+  - dataset_name: xeno-canto
+    split: validation
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.02
+  - dataset_name: inaturalist
+    split: val
+    sample_rate: 16000
+    audio_max_length_seconds: 10
+    subset_percentage: 0.05
+
+concatenate_train: true
+concatenate_val: true
+concatenate_method: soft
+
+transformations:
+  - type: labels_from_features
+    features: [labels, canonical_name]
+    output_feature: label
+    override: true
+    allow_missing_labels: false
+  - type: deduplicate
+    subset: ['local_path']

--- a/configs/data_configs/individual_id_gcs.yml
+++ b/configs/data_configs/individual_id_gcs.yml
@@ -1,0 +1,629 @@
+# yamllint disable rule:indentation
+benchmark_name: individual_id_benchmark
+evaluation_sets:
+- name: pipit_id_across_year
+  train:
+    dataset_name: pipit_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        212: 0
+        312: 1
+        712: 2
+        811: 3
+        911: 4
+        1011: 5
+        1211: 6
+        1511: 7
+        1611: 8
+        1711: 9
+  validation:
+    dataset_name: pipit_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        212: 0
+        312: 1
+        712: 2
+        811: 3
+        911: 4
+        1011: 5
+        1211: 6
+        1511: 7
+        1611: 8
+        1711: 9
+  test:
+    dataset_name: pipit_id
+    split: test_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        212: 0
+        312: 1
+        712: 2
+        811: 3
+        911: 4
+        1011: 5
+        1211: 6
+        1511: 7
+        1611: 8
+        1711: 9
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: chiffchaff_id_across_year
+  train:
+    dataset_name: chiffchaff_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        F72726: 0
+        F91903: 1
+        F91907: 2
+        F91913: 3
+        F91915: 4
+        F91916: 5
+        F91954: 6
+        F91959: 7
+        F91969: 8
+        F91973: 9
+  validation:
+    dataset_name: chiffchaff_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        F72726: 0
+        F91903: 1
+        F91907: 2
+        F91913: 3
+        F91915: 4
+        F91916: 5
+        F91954: 6
+        F91959: 7
+        F91969: 8
+        F91973: 9
+  test:
+    dataset_name: chiffchaff_id
+    split: test_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        F72726: 0
+        F91903: 1
+        F91907: 2
+        F91913: 3
+        F91915: 4
+        F91916: 5
+        F91954: 6
+        F91959: 7
+        F91969: 8
+        F91973: 9
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: macaques_individual_id
+  train:
+    dataset_name: macaques_coo_calls
+    split: train
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: id
+      override: true
+      label_map:
+        AL: 0
+        BE: 1
+        IO: 2
+        MU: 3
+        QU: 4
+        SN: 5
+        TH: 6
+        TW: 7
+  validation:
+    dataset_name: macaques_coo_calls
+    split: val
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: id
+      override: true
+      label_map:
+        AL: 0
+        BE: 1
+        IO: 2
+        MU: 3
+        QU: 4
+        SN: 5
+        TH: 6
+        TW: 7
+  test:
+    dataset_name: macaques_coo_calls
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: id
+      override: true
+      label_map:
+        AL: 0
+        BE: 1
+        IO: 2
+        MU: 3
+        QU: 4
+        SN: 5
+        TH: 6
+        TW: 7
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: littleowl_id_across_year
+  train:
+    dataset_name: littleowl_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        '108': 0
+        '193': 1
+        '229': 2
+        '7': 3
+        '94': 4
+        BRE: 5
+        CER: 6
+        DUB: 7
+        KME: 8
+        LIS: 9
+        MNE: 10
+        PAL: 11
+        RAC: 12
+        RADBF: 13
+        RADK: 14
+        VEV: 15
+  validation:
+    dataset_name: littleowl_id
+    split: train_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        '108': 0
+        '193': 1
+        '229': 2
+        '7': 3
+        '94': 4
+        BRE: 5
+        CER: 6
+        DUB: 7
+        KME: 8
+        LIS: 9
+        MNE: 10
+        PAL: 11
+        RAC: 12
+        RADBF: 13
+        RADK: 14
+        VEV: 15
+  test:
+    dataset_name: littleowl_id
+    split: test_across_year
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: individual_id
+      override: true
+      label_map:
+        '108': 0
+        '193': 1
+        '229': 2
+        '7': 3
+        '94': 4
+        BRE: 5
+        CER: 6
+        DUB: 7
+        KME: 8
+        LIS: 9
+        MNE: 10
+        PAL: 11
+        RAC: 12
+        RADBF: 13
+        RADK: 14
+        VEV: 15
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: zebra_finch_call_type
+  train:
+    dataset_name: zebra_finch_julie_elie
+    split: train
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_1
+      override: true
+      label_map:
+        alarm: 0
+        contact: 1
+        distress: 2
+        nest: 3
+        unknown: 4
+  validation:
+    dataset_name: zebra_finch_julie_elie
+    split: val
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_1
+      override: true
+      label_map:
+        alarm: 0
+        contact: 1
+        distress: 2
+        nest: 3
+        unknown: 4
+  test:
+    dataset_name: zebra_finch_julie_elie
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_1
+      override: true
+      label_map:
+        alarm: 0
+        contact: 1
+        distress: 2
+        nest: 3
+        unknown: 4
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: zebra_finch_call_type_id
+  train:
+    dataset_name: zebra_finch_julie_elie
+    split: train
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_id
+      override: true
+      label_map:
+        '01': 0
+        '02': 1
+        '03': 2
+        '04': 3
+        '05': 4
+        '06': 5
+        '07': 6
+        08: 7
+        09: 8
+        '10': 9
+        '11': 10
+        '12': 11
+        '13': 12
+        '14': 13
+        '15': 14
+        '16': 15
+        '17': 16
+        '18': 17
+        '19': 18
+        '20': 19
+        '21': 20
+        '22': 21
+        '23': 22
+        '24': 23
+        '25': 24
+        '26': 25
+        '27': 26
+        '28': 27
+        '29': 28
+        '30': 29
+        '31': 30
+        '32': 31
+        '33': 32
+        '34': 33
+        Ag: 34
+        Be: 35
+        DC: 36
+        Di: 37
+        LT: 38
+        Ne: 39
+        So: 40
+        Te: 41
+        Th: 42
+        Tu: 43
+        WC: 44
+        Wh: 45
+  validation:
+    dataset_name: zebra_finch_julie_elie
+    split: val
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_id
+      override: true
+      label_map:
+        '01': 0
+        '02': 1
+        '03': 2
+        '04': 3
+        '05': 4
+        '06': 5
+        '07': 6
+        08: 7
+        09: 8
+        '10': 9
+        '11': 10
+        '12': 11
+        '13': 12
+        '14': 13
+        '15': 14
+        '16': 15
+        '17': 16
+        '18': 17
+        '19': 18
+        '20': 19
+        '21': 20
+        '22': 21
+        '23': 22
+        '24': 23
+        '25': 24
+        '26': 25
+        '27': 26
+        '28': 27
+        '29': 28
+        '30': 29
+        '31': 30
+        '32': 31
+        '33': 32
+        '34': 33
+        Ag: 34
+        Be: 35
+        DC: 36
+        Di: 37
+        LT: 38
+        Ne: 39
+        So: 40
+        Te: 41
+        Th: 42
+        Tu: 43
+        WC: 44
+        Wh: 45
+  test:
+    dataset_name: zebra_finch_julie_elie
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: call_type_id
+      override: true
+      label_map:
+        '01': 0
+        '02': 1
+        '03': 2
+        '04': 3
+        '05': 4
+        '06': 5
+        '07': 6
+        08: 7
+        09: 8
+        '10': 9
+        '11': 10
+        '12': 11
+        '13': 12
+        '14': 13
+        '15': 14
+        '16': 15
+        '17': 16
+        '18': 17
+        '19': 18
+        '20': 19
+        '21': 20
+        '22': 21
+        '23': 22
+        '24': 23
+        '25': 24
+        '26': 25
+        '27': 26
+        '28': 27
+        '29': 28
+        '30': 29
+        '31': 30
+        '32': 31
+        '33': 32
+        '34': 33
+        Ag: 34
+        Be: 35
+        DC: 36
+        Di: 37
+        LT: 38
+        Ne: 39
+        So: 40
+        Te: 41
+        Th: 42
+        Tu: 43
+        WC: 44
+        Wh: 45
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette
+- name: giant_otters_vocalization
+  train:
+    dataset_name: giant_otters
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: vocalization
+      override: true
+      label_map:
+        Bark: 0
+        Bark-like vocalization: 1
+        Begging Scream: 2
+        Begging call: 3
+        Begging call-like vocalization: 4
+        Begging scream gradat: 5
+        Close Call: 6
+        Contact Call: 7
+        Contact call gradation: 8
+        Contact call-like vocalization: 9
+        Distress call 1: 10
+        Distress call 2: 11
+        Growl: 12
+        Hah!: 13
+        High whistle: 14
+        Hum: 15
+        Hum gradation: 16
+        Hum gradation-like vocalization: 17
+        Hum short: 18
+        Hum-like vocalization: 19
+        Isolation Call: 20
+        Low whistle: 21
+        Scream Ascending: 22
+        Snort: 23
+        Suckling Call: 24
+        Suckling call: 25
+        Wavering Scream: 26
+        Whine: 27
+        Whistle: 28
+        Whistle Double: 29
+        under water call: 30
+        whine: 31
+  validation:
+    dataset_name: giant_otters
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: vocalization
+      override: true
+      label_map:
+        Bark: 0
+        Bark-like vocalization: 1
+        Begging Scream: 2
+        Begging call: 3
+        Begging call-like vocalization: 4
+        Begging scream gradat: 5
+        Close Call: 6
+        Contact Call: 7
+        Contact call gradation: 8
+        Contact call-like vocalization: 9
+        Distress call 1: 10
+        Distress call 2: 11
+        Growl: 12
+        Hah!: 13
+        High whistle: 14
+        Hum: 15
+        Hum gradation: 16
+        Hum gradation-like vocalization: 17
+        Hum short: 18
+        Hum-like vocalization: 19
+        Isolation Call: 20
+        Low whistle: 21
+        Scream Ascending: 22
+        Snort: 23
+        Suckling Call: 24
+        Suckling call: 25
+        Wavering Scream: 26
+        Whine: 27
+        Whistle: 28
+        Whistle Double: 29
+        under water call: 30
+        whine: 31
+  test:
+    dataset_name: giant_otters
+    split: test
+    sample_rate: 16000
+    transformations:
+    - type: label_from_feature
+      feature: vocalization
+      override: true
+      label_map:
+        Bark: 0
+        Bark-like vocalization: 1
+        Begging Scream: 2
+        Begging call: 3
+        Begging call-like vocalization: 4
+        Begging scream gradat: 5
+        Close Call: 6
+        Contact Call: 7
+        Contact call gradation: 8
+        Contact call-like vocalization: 9
+        Distress call 1: 10
+        Distress call 2: 11
+        Growl: 12
+        Hah!: 13
+        High whistle: 14
+        Hum: 15
+        Hum gradation: 16
+        Hum gradation-like vocalization: 17
+        Hum short: 18
+        Hum-like vocalization: 19
+        Isolation Call: 20
+        Low whistle: 21
+        Scream Ascending: 22
+        Snort: 23
+        Suckling Call: 24
+        Suckling call: 25
+        Wavering Scream: 26
+        Whine: 27
+        Whistle: 28
+        Whistle Double: 29
+        under water call: 30
+        whine: 31
+  metrics:
+  - accuracy
+  - multiclass_f1
+  - clustering_ari
+  - clustering_nmi
+  - clustering_v_measure
+  - clustering_silhouette

--- a/configs/evaluation_configs/icassp_2026/eat_ssl_all_retrieval.yml
+++ b/configs/evaluation_configs/icassp_2026/eat_ssl_all_retrieval.yml
@@ -1,0 +1,31 @@
+# Retrieval + clustering for SSL EAT-all (esp_aves2_eat_all), to reproduce paper Table 6.
+dataset_config: configs/data_configs/benchmark_id_repertoire_48khz.yml
+training_params:
+  train_epochs: 1
+  lr: 0.001
+  batch_size: 32
+  optimizer: adamw
+  weight_decay: 0.01
+  amp: false
+experiments:
+  - run_name: eat_ssl_all
+    run_config: configs/run_configs/icassp_2026/eat_ssl_all.yml
+    pretrained: false
+    checkpoint_path: hf://EarthSpeciesProject/esp-aves2-eat-all/esp-aves2-eat-all.safetensors
+    probe_config:
+      probe_type: linear
+      target_layers: ["backbone.model.blocks.11.mlp.fc2"]
+      aggregation: "mean"
+      input_processing: "pooled"
+      freeze_backbone: true
+      online_training: false
+save_dir: evaluation_results/icassp2026_eat_ssl_all
+results_csv_path: evaluation_results/icassp2026_eat_ssl_all/results.csv
+device: cuda
+seed: 42
+num_workers: 8
+eval_modes:
+  - retrieval
+  - clustering
+offline_embeddings:
+  overwrite_embeddings: true

--- a/configs/run_configs/icassp_2026/eat_ssl_all.yml
+++ b/configs/run_configs/icassp_2026/eat_ssl_all.yml
@@ -1,0 +1,36 @@
+---
+# SSL EAT trained on all (AudioSet + bioacoustics) — the published esp_aves2_eat_all.
+# Weights via hf:// (checkpoint_path set in the eval experiment).
+model_spec:
+  name: eat_hf
+  pretrained: false
+  device: cuda
+  eat_norm_mean: -5.553
+  eat_norm_std: 4.606
+  audio_config:
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+
+dataset_config: configs/data_configs/data_base.yml
+run_name: eat_ssl_all
+output_dir: "./runs/icassp2026/eat_ssl_all"
+loss_function: cross_entropy
+label_type: supervised
+preprocessing: null
+sr: 16000
+debug_mode: false
+logging: mlflow
+resume_from_checkpoint: null
+training_params:
+  train_epochs: 1
+  lr: 0.001
+  batch_size: 32
+  optimizer: adamw
+  weight_decay: 0.01
+  amp: false
+seed: 42
+num_workers: 8
+augmentations: []

--- a/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat.yml
+++ b/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat.yml
@@ -47,7 +47,24 @@ scheduler:
   warmup_steps: 2000
   min_lr: 1e-6
 
-# Original recipe used background-noise augmentation, but those noise dirs
-# (/home/milad_.../audio_16k/noise/*) are missing here -> disabled to avoid a
-# "Noise directory not found" crash. Re-add if the noise corpus is available.
-augmentations: []
+# Background-noise augmentation (+ signal masking) and mixup, matching the
+# reference EAT recipe. Noise corpus lives on GCS (16 kHz, matches sample_rate).
+augmentations:
+  - noise:
+      noise_dirs:
+        - gs://foundation-model-data/audio_16k/noise_clean/demand_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/idmt
+        - gs://foundation-model-data/audio_16k/noise_clean/tut2016_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/urbansound
+        - gs://foundation-model-data/audio_16k/noise_clean/orcasound_shipnoise_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/deepship_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/shipsear_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/wham_noise
+        # audioset noise dir is empty at 16 kHz (0 wav) -> omitted; 8 dirs, ~65k files
+      snr_db_range: [-5, 20]
+      augmentation_prob: 0.5
+      mask_signal_prob: 0.1   # 10% of noised items: drop signal, keep only noise
+  - mixup:
+      alpha: 0.4
+      n_mixup: 1
+      augmentation_prob: 0.5

--- a/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat.yml
+++ b/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat.yml
@@ -1,0 +1,53 @@
+---
+# ICASSP 2026: supervised post-training of SSL EAT on AudioSet + Xeno-canto + iNaturalist
+# (separate alp-data datasets). Mirrors aaai_train/sl_eat_animalspeak_ssl_all_h100.yml but
+# points at the split-dataset corpus. Run with: avex train --config <this>.
+model_spec:
+  name: eat_hf
+  pretrained: false
+  device: cuda
+  # SSL init = the released HF EAT pretrain checkpoint
+  # (worstchan/EAT-base_epoch30_pretrain), loaded by eat_hf's AutoModel.from_pretrained.
+  # `fairseq_weights_path` is only needed to override that with a local fairseq
+  # SSL checkpoint; the old path no longer exists, so we init from the HF weights.
+  eat_norm_mean: -5.553
+  eat_norm_std: 4.606
+  audio_config:
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+
+dataset_config: configs/data_configs/icassp_2026/data_audioset_xeno_inat.yml
+output_dir: "./runs/icassp2026/sl_eat_audioset_xeno_inat"
+run_name: sl_eat_audioset_xeno_inat
+label_type: supervised
+loss_function: bce           # multi-label (AudioSet ontology + species)
+preprocessing: null
+sr: 16000
+debug_mode: false
+logging: wandb
+resume_from_checkpoint: null
+
+training_params:
+  train_epochs: 10
+  lr: 0.0001
+  batch_size: 128
+  optimizer: adamw8bit
+  weight_decay: 0.01
+  amp: true
+  amp_dtype: bf16
+  freeze_backbone_epochs: 2
+  second_stage_lr: 0.00008
+  second_stage_warmup_steps: 6000
+
+scheduler:
+  name: cosine
+  warmup_steps: 2000
+  min_lr: 1e-6
+
+# Original recipe used background-noise augmentation, but those noise dirs
+# (/home/milad_.../audio_16k/noise/*) are missing here -> disabled to avoid a
+# "Noise directory not found" crash. Re-add if the noise corpus is available.
+augmentations: []

--- a/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat_smoke.yml
+++ b/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat_smoke.yml
@@ -1,0 +1,49 @@
+---
+# SMOKE test of the icassp_2026 EAT supervised post-training pipeline on a single H100:
+# tiny data subsets, no wandb, backbone unfrozen from step 0 so the full trainable path
+# (backbone + head, bf16 amp, adamw8bit, BCE multi-label) is exercised. Confirms the
+# training + data configs build and step end-to-end. NOT a real training run.
+model_spec:
+  name: eat_hf
+  pretrained: false
+  device: cuda
+  # SSL init = HF EAT pretrain (worstchan/EAT-base_epoch30_pretrain) via AutoModel.from_pretrained.
+  eat_norm_mean: -5.553
+  eat_norm_std: 4.606
+  audio_config:
+    sample_rate: 16000
+    representation: raw
+    normalize: false
+    target_length_seconds: 10
+    window_selection: random
+
+dataset_config: configs/data_configs/icassp_2026/data_audioset_xeno_inat_smoke.yml
+output_dir: "./runs/icassp2026/smoke_sl_eat_audioset_xeno_inat"
+run_name: smoke_sl_eat_audioset_xeno_inat
+label_type: supervised
+loss_function: bce
+preprocessing: null
+sr: 16000
+debug_mode: false
+logging: none
+resume_from_checkpoint: null
+
+training_params:
+  train_epochs: 1
+  lr: 0.0001
+  batch_size: 8
+  optimizer: adamw8bit
+  weight_decay: 0.01
+  amp: true
+  amp_dtype: bf16
+  freeze_backbone_epochs: 0
+  second_stage_lr: 0.00008
+  second_stage_warmup_steps: 100
+  log_steps: 1
+
+scheduler:
+  name: cosine
+  warmup_steps: 10
+  min_lr: 1e-6
+
+augmentations: []

--- a/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat_smoke.yml
+++ b/configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat_smoke.yml
@@ -46,4 +46,17 @@ scheduler:
   warmup_steps: 10
   min_lr: 1e-6
 
-augmentations: []
+# Noise + signal-masking + mixup enabled so the smoke run exercises them.
+# High probs + small noise dirs so they reliably fire and start fast.
+augmentations:
+  - noise:
+      noise_dirs:
+        - gs://foundation-model-data/audio_16k/noise_clean/demand_10s
+        - gs://foundation-model-data/audio_16k/noise_clean/tut2016_10s
+      snr_db_range: [-5, 20]
+      augmentation_prob: 1.0
+      mask_signal_prob: 0.3
+  - mixup:
+      alpha: 0.4
+      n_mixup: 1
+      augmentation_prob: 1.0

--- a/jobs/icassp_2026/eval_eat_ssl_all_retrieval.sh
+++ b/jobs/icassp_2026/eval_eat_ssl_all_retrieval.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# (b) Evaluate eat_ssl_all (esp-aves2-eat-all, hf://) by retrieval + clustering across
+#     the AVEX benchmark, one dataset per array task. Results land under
+#     evaluation_results/icassp2026_eat_ssl_all_<tag>/results.csv (aggregate with
+#     ~/agg_results.py). Submit:  sbatch jobs/icassp_2026/eval_eat_ssl_all_retrieval.sh
+
+#SBATCH --partition=h100-80
+#SBATCH --array=1-4%4
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-gpu=16
+#SBATCH --output="/home/%u/logs/%A_%a.log"
+#SBATCH --job-name="eat-retr"
+#SBATCH --qos=naturelm
+
+cd ~/avex
+uv sync --group project-dev --group gpu
+export CLOUDPATHLIB_FORCE_OVERWRITE_FROM_CLOUD=1
+
+case "$SLURM_ARRAY_TASK_ID" in
+  1) DS=configs/data_configs/benchmark_beans_gcs.yml;           TAG=beans ;;
+  2) DS=configs/data_configs/benchmark_birdset_gs.yml;          TAG=birdset ;;
+  3) DS=configs/data_configs/benchmark_id_repertoire_48khz.yml; TAG=repertoire ;;
+  4) DS=configs/data_configs/individual_id_gcs.yml;             TAG=individual_id ;;
+esac
+
+srun uv run avex evaluate \
+    --config configs/evaluation_configs/icassp_2026/eat_ssl_all_retrieval.yml \
+    --patch "dataset_config=${DS}" \
+    --patch "save_dir=evaluation_results/icassp2026_eat_ssl_all_${TAG}" \
+    --patch "results_csv_path=evaluation_results/icassp2026_eat_ssl_all_${TAG}/results.csv"

--- a/jobs/icassp_2026/train_eat_audioset_xeno_inat_h100.sh
+++ b/jobs/icassp_2026/train_eat_audioset_xeno_inat_h100.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# (a) Post-train EAT (SSL init) supervised on AudioSet + Xeno-canto + iNaturalist,
+#     single H100. Joint multi-label space over {AudioSet classes} U {species}.
+#     Submit:  sbatch jobs/icassp_2026/train_eat_audioset_xeno_inat_h100.sh
+
+#SBATCH --partition=h100-80
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-gpu=16
+#SBATCH --output="/home/%u/logs/%A.log"
+#SBATCH --job-name="eat-sl-train"
+#SBATCH --qos=naturelm
+
+cd ~/avex
+uv sync --group project-dev --group gpu
+
+srun uv run avex train \
+    --config configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat.yml
+
+# Smoke test instead (tiny subsets, no wandb, verifies configs build + step):
+#   srun uv run avex train \
+#       --config configs/run_configs/icassp_2026/sl_eat_audioset_xeno_inat_smoke.yml


### PR DESCRIPTION
## What this does

Wires up the ICASSP 2026 EAT experiments and fixes several general
eval/training-pipeline bugs found while getting them to run. All changes are on
top of `main` (v1.3.0). New experiment configs live under `configs/*/icassp_2026/`.

## Pipeline bug fixes (affect any model, not just EAT)

- **`run_evaluate` loaded random backbones.** Experiment `checkpoint_path` was loaded with a naive `load_state_dict(strict=False)` that didn't reconcile the wrapper's `backbone.` prefix, so flat/nested checkpoints matched **0 keys → chance-level retrieval** with no error. Now routed through the prefix-aware `avex.models.utils.load._load_checkpoint`. Also builds feature extractors with `return_features_only=True` (`eat_hf` raises `num_classes must be > 0` otherwise; BEATs happened to fall back).
- **`_load_checkpoint` prefix reconciliation generalized.** Previously only added/stripped a single-level `backbone.`; now handles arbitrary nested prefixes, e.g. an EAT checkpoint's `blocks.*` → `backbone.model.blocks.*` (144/150 params matched vs 0 before).
- **Global (post-concat) training transforms crashed.** `DatasetCollectionConfig.transformations` was typed `list | None` and passed raw YAML dicts straight to `apply_transformations`, which needs typed `RegisteredTransformConfigs` (`cfg.type`) → `KeyError: <class 'dict'>`. Any training config using post-concat transforms was broken. Added a `field_validator` that converts the dicts via `TypeAdapter(RegisteredTransformConfigs)`, mirroring alp_data's own per-dataset validator.
- **val/test rebuilt their own label maps.** `_build_datasets` re-fit `labels_from_features` on val/test (fresh, independent id assignment) yet handed them the *train* `label_map` as metadata — so val/test target ids silently disagreed with the model's output layer. Now the train-fitted `label_map` is pinned onto the label-building transform for val/test.
- **torch ≥ 2.11 compat** in the streaming embedding extractor (`torch.Size` → plain tuple).
- **Masked pooling** in `beats_model.extract_embeddings` (mean/max now exclude padded frames, matching `forward()`).

## New

- **`avex/data/parse_json_list.py`** — transform that decodes JSON-string list columns into real lists before label building. Without it, `labels_from_features` treats a whole JSON string (`'["Music","Speech"]'`) as one opaque label. Needed for AudioSet `labels` and BirdSet `ebird_code_multilabel`.
- **`configs/evaluation_configs/icassp_2026/eat_ssl_all_retrieval.yml` + `configs/run_configs/icassp_2026/eat_ssl_all.yml`** — frozen-backbone retrieval/clustering eval of `eat_ssl_all` (`eat_hf`, layer `backbone.model.blocks.11.mlp.fc2`, mean pooling).
- **`configs/*/icassp_2026/…audioset_xeno_inat…`** — supervised post-training of EAT on **AudioSet + Xeno-canto + iNaturalist** as the now-separate alp-data datasets. Init is the released HF EAT pretrain (`worstchan/EAT-base_epoch30_pretrain`); `fairseq_weights_path` is optional if a local SSL checkpoint is available. Includes a single-GPU smoke variant.

### Joint multi-label space (the tricky part)

AudioSet is multi-label (`labels`, a JSON string) and Xeno/iNat are single-label (`canonical_name`, a species string). The config keeps each dataset's **native** label column and gives the global builder both: `labels_from_features features: [labels, canonical_name]`. `MultiLabelFromFeatures` unions across the columns — a scalar string is one atomic label, a list is iterated — so every column stays single-typed after `soft` concat (no mixed List+str that would break polars). `parse_json_list` on AudioSet turns its JSON string into a real class list first.

**Verified** on the full corpus: Xeno-canto (10,790 species) ∪ iNaturalist (9,126) with **6,095 shared species** → **13,821 unique species + 527 AudioSet classes = 14,348 labels**, and every shared species collapses to exactly one id. A single-H100 smoke run built the model (`num_classes=14348`), loaded the EAT backbone, and stepped end-to-end (BCE multi-label, bf16, adamw8bit, loss decreasing).

## Notes / scope

- Focused on the EAT + training work and the pipeline fixes. The NatureLM-32kHz benchmark configs, CLAP/caption data scripts, and slurm job scripts from the same working tree were left out of this PR to keep it coherent and CI-clean; happy to land them separately.
- `subset_percentage` did not shrink the AudioSet split in the smoke run (likely ignored by AudioSet's custom config) — irrelevant to the full training config, but noted for fast local iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)