### PR TITLE
Add esp-aves2-sed-birdcode BEATs encoder as an official model

### DIFF
--- a/avex/api/configs/official_models/esp_aves2_sed_birdcode_beats_encoder.yml
+++ b/avex/api/configs/official_models/esp_aves2_sed_birdcode_beats_encoder.yml
@@ -1,0 +1,68 @@
+---
+# ESP-AVES2: encoder-only BEATs backbone from the sed-birdcode SED ablation
+# (`sed-birdcode-ablation-ssl_beats_clip_pseudo`).
+#
+# Registry key is deliberately shorter than the Hub repo / GCS folder name
+# (esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder), which would
+# otherwise be a 61-character identifier for callers to type. checkpoint_path
+# below carries the full repo name.
+#
+# Encoder only: the source run's frame-level SED head (Linear(6144, 7475)) is
+# not published, so this model always loads in embedding-extraction mode. No
+# class_mapping_path is provided.
+#
+# Weights are hosted on the Hugging Face Hub as a safetensors file.
+# The loader supports `hf://` URIs via huggingface_hub's fsspec filesystem.
+checkpoint_path: hf://EarthSpeciesProject/esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder/esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder.safetensors
+
+model_spec:
+  name: beats
+  pretrained: false
+  fine_tuned: false
+  device: cuda
+  init_config:
+    activation_dropout: 0.0
+    activation_fn: gelu
+    attention_dropout: 0.0
+    conv_bias: false
+    conv_pos: 128
+    conv_pos_groups: 16
+    deep_norm: true
+    dropout: 0.0
+    dropout_input: 0.0
+    embed_dim: 512
+    encoder_attention_heads: 12
+    encoder_embed_dim: 768
+    encoder_ffn_embed_dim: 3072
+    encoder_layerdrop: 0.0
+    encoder_layers: 12
+    finetuned_model: false
+    gru_rel_pos: true
+    input_patch_size: 16
+    layer_norm_first: false
+    layer_wise_gradient_decay_ratio: 1.0
+    max_distance: 800
+    num_buckets: 320
+    predictor_class: 527
+    predictor_dropout: 0.0
+    relative_position_embedding: true
+    # Must stay 16000 even though audio is delivered at 32000 Hz. This is a
+    # parameter of the fbank extractor, not a declaration of the input rate: it
+    # fixes the window (25 ms * 16000 = 400 samples), hop (160 samples), and mel
+    # filterbank (257 x 128), all of which are frozen in the checkpoint as the
+    # buffers backbone.fbank.window and backbone.fbank.mel_fb. Setting 32000
+    # rebuilds them at (800,) and (513, 128) and the checkpoint fails to load.
+    sample_frequency: 16000.0
+    num_mel_bins: 128
+    frame_length: 25.0
+    frame_shift: 10.0
+    fbank_mean: 15.41663
+    fbank_std: 6.55582
+  # 32 kHz / 5.0 s -> 160000 samples -> 496 tokens (62 time x 8 freq).
+  # Do not resample to 16 kHz: it loads but degrades the representation.
+  audio_config:
+    sample_rate: 32000
+    representation: raw
+    normalize: false
+    target_length_seconds: 5
+    window_selection: random

--- a/scripts/upload_esp_aves2_models_to_hf.py
+++ b/scripts/upload_esp_aves2_models_to_hf.py
@@ -59,6 +59,7 @@ DEFAULT_MODELS: tuple[str, ...] = (
     "esp-aves2-effnetb0-audioset",
     "esp-aves2-effnetb0-bio",
     "esp-aves2-naturelm-audio-v1-beats",
+    "esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder",
     "esp-aves2-sl-beats-all",
     "esp-aves2-sl-beats-bio",
     "esp-aves2-sl-eat-all-ssl-all",

--- a/tests/integration/test_official_models_output_regression.py
+++ b/tests/integration/test_official_models_output_regression.py
@@ -34,6 +34,10 @@ _OFFICIAL_MODEL_OUTPUT_FINGERPRINTS_BY_PROFILE: Final[dict[str, dict[str, str]]]
         "esp_aves2_effnetb0_audioset": "8ba36f99b5e8245d7b61fc472339f5760fabca19d63a51e835309c11a379eab6",
         "esp_aves2_effnetb0_bio": "c91dde6bee57788951a0fb9044703d301cb295e83fdc5e064874b63c99c70493",
         "esp_aves2_naturelm_audio_v1_beats": "c1689532213d32cc16b0f7eb1774239c4d4bbd91a0500b551d4468acf52cb9d1",
+        # TODO: regenerate on a torch 2.5.x env --
+        # scripts/regenerate_official_model_output_fingerprints.py --profile torch_2_5_0
+        # Placeholder below is the torch 2.11 value and will NOT match.
+        "esp_aves2_sed_birdcode_beats_encoder": "e6cf6dc452aa175883e712c85470d35bc4c152f022b82157a1eb7853931a9c9c",
         "esp_aves2_sl_beats_all": "b6231fdcb855734ebfddf26e793a46d8e4b3bf61ee950273fdd85affcf85eefe",
         "esp_aves2_sl_beats_bio": "1ad22272d36f3e74d64c5fb98ec31810c9281c1c32e9a2178f10c08004c8bcd6",
         "esp_aves2_sl_eat_all_ssl_all": "0832f0c78523167e0a5439b9a4e96caf115131118549ff9161a01bd6d03a5b2e",
@@ -47,6 +51,10 @@ _OFFICIAL_MODEL_OUTPUT_FINGERPRINTS_BY_PROFILE: Final[dict[str, dict[str, str]]]
         "esp_aves2_effnetb0_audioset": "1fbe57dd3b795aea08c66ed5c45731cce5a08835b9c33676057d6e5d361c52ae",
         "esp_aves2_effnetb0_bio": "3123856a920e27271a26fe29437119a90e2ebd5436d4bb9a4629d08828fef8ef",
         "esp_aves2_naturelm_audio_v1_beats": "248a36d3772d847119b44969be19a4ba70a6302557f58a700dc9fd14ff0af9f3",
+        # TODO: regenerate on a torch 2.6.x env --
+        # scripts/regenerate_official_model_output_fingerprints.py --profile torch_2_6_0
+        # Placeholder below is the torch 2.11 value and will NOT match.
+        "esp_aves2_sed_birdcode_beats_encoder": "e6cf6dc452aa175883e712c85470d35bc4c152f022b82157a1eb7853931a9c9c",
         "esp_aves2_sl_beats_all": "c01e92839305633644aa62346b3b3a4cf086e46083ae6db2b7f4b3fede3a8f5d",
         "esp_aves2_sl_beats_bio": "1c9e8459e2cf0038a0d062b3f414d18678d10997db95300aa7f1dc7288411fb2",
         "esp_aves2_sl_eat_all_ssl_all": "cc2ce5ffe5a91c79552cddd5401fe001bcaf28abeb79f39dddae69c14cd93b73",
@@ -60,6 +68,7 @@ _OFFICIAL_MODEL_OUTPUT_FINGERPRINTS_BY_PROFILE: Final[dict[str, dict[str, str]]]
         "esp_aves2_effnetb0_audioset": "1fbe57dd3b795aea08c66ed5c45731cce5a08835b9c33676057d6e5d361c52ae",
         "esp_aves2_effnetb0_bio": "3123856a920e27271a26fe29437119a90e2ebd5436d4bb9a4629d08828fef8ef",
         "esp_aves2_naturelm_audio_v1_beats": "a7c6ccf25fb251603c747c47ccdf632ddb703d0a7e5b7f4525e0f7e6788e34d0",
+        "esp_aves2_sed_birdcode_beats_encoder": "e6cf6dc452aa175883e712c85470d35bc4c152f022b82157a1eb7853931a9c9c",
         "esp_aves2_sl_beats_all": "7dedd023d6b167c3aa23cfa5461cca3fd80cc5411e32598cc29941fe1820dcbf",
         "esp_aves2_sl_beats_bio": "824b0aa66302d4fe4fee452913c81770eb7f1bd63653890a0d84ede5ac461851",
         "esp_aves2_sl_eat_all_ssl_all": "cc21667c9aca79fc2fb946685b28c7ef5dfee587181297d52fc5110832e05616",

--- a/tests/unittests/test_official_models_checksums.py
+++ b/tests/unittests/test_official_models_checksums.py
@@ -32,6 +32,7 @@ OFFICIAL_MODEL_CHECKSUMS: dict[str, str] = {
     "esp_aves2_effnetb0_audioset": "58455bac5346a8c8d705b20210edfd14a5f6151fed9dd61320bda2e31030119c",
     "esp_aves2_effnetb0_bio": "e34db5a8951f28f4d90cb06b396f4a4e716dd79e48a54e672017d832804868d7",
     "esp_aves2_naturelm_audio_v1_beats": "ce2c16141465e11852105eaee4a32bbb4663cfe8cf7a49ddc874ea5c267f78a2",
+    "esp_aves2_sed_birdcode_beats_encoder": "8e48088f3396e69dfca72cca89ed4eb67d0cd38910ce8cc9f611e572d3ea5c21",
     "esp_aves2_sl_beats_all": "25dc242853822de6e35228b22c285886162b5f787d162280e0277c010a510e91",
     "esp_aves2_sl_beats_bio": "1881788eb6d059d7b005e1c68235906fcb12bf3a6cde824cec7cbdc34dcb9fc3",
     "esp_aves2_sl_eat_all_ssl_all": "af10ff12eb15b0e1343348d787b4ccb97bd3e4fe11147140c68ba646d64130cc",


### PR DESCRIPTION
Registers the encoder-only BEATs backbone from the `sed-birdcode-ablation-ssl_beats_clip_pseudo` run, so it shows up in `list_models()` and loads by name:

```python
from avex import load_model
backbone = load_model("esp_aves2_sed_birdcode_beats_encoder", device="cuda")
```

`list_models()` goes from 10 to 11 entries.

## What was published

The source checkpoint stored its backbone under an `encoder._model.backbone.*` prefix and carried a frame-level SED head, `Linear(6144, 7475)`. Publishing involved two changes, both lossless for the backbone:

1. Key prefix `encoder._model.backbone.*` → `backbone.*`, matching `avex.models.beats_model.Model`.
2. The head was dropped — 252 backbone tensors kept, 2 head tensors removed.

`load_model` reports **252/252 params matched, 0 unexpected** and auto-selects embedding mode (no classifier in the checkpoint → `num_classes=None`). Backbone weights are **bitwise identical** to the source, verified by a `strict=True` load and by comparing forward-pass outputs.

Artifacts live in GCS at `gs://representation-learning/esp-avex/models/esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder/` and on the Hub at [`EarthSpeciesProject/esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder`](https://huggingface.co/EarthSpeciesProject/esp-aves2-sed-birdcode-ablation-ssl-beats-clip-pseudo-encoder).

## Input contract — not the AVEX defaults

| Setting | Value |
|---|---|
| `audio_config.sample_rate` | **32000** |
| `audio_config.target_length_seconds` | **5.0** |
| `init_config.sample_frequency` | **16000** — do not change |

`sample_frequency` is a parameter of the fbank extractor, not a declaration of the input rate. It fixes the window (400 samples), hop (160), and mel filterbank (257 × 128), all frozen in the checkpoint as `backbone.fbank.window` `(400,)` and `backbone.fbank.mel_fb` `(257, 128)`. Setting it to 32000 rebuilds them at `(800,)` and `(513, 128)` and **the checkpoint fails to load**.

So 32 kHz audio runs through a 16 kHz fbank: windows span 12.5 ms of real time and content at true frequency *f* is analysed at *f*/2. 5.0 s yields 496 tokens (62 time × 8 freq) of dim 768. Two failure modes: resampling input to 16 kHz loads but silently degrades; changing `sample_frequency` won't load at all. Documented in the YAML and the model card.

## Registry key naming

The key is deliberately shorter than the Hub repo / GCS folder name, which would otherwise be a 61-character identifier for callers to type — and which pushed the checksum/fingerprint table lines past the 120-column ruff limit. `checkpoint_path` in the YAML carries the full repo name.

## Blockers before merge

- [ ] **Two fingerprint profiles are placeholders.** `test_reference_table_covers_all_official_hf_models` requires an entry in every profile, and `torch_2_5_0` / `torch_2_6_0` cannot be computed from a torch 2.11 environment. Both currently hold the torch 2.11 value and are marked `TODO`; they will **not** match. Regenerate from those environments:
  ```
  uv run python scripts/regenerate_official_model_output_fingerprints.py --profile torch_2_5_0
  uv run python scripts/regenerate_official_model_output_fingerprints.py --profile torch_2_6_0
  ```
  `torch_2_11_0` was computed and verified locally.
- [ ] **The Hub repo is private.** Network-dependent tests (`test_official_models_checksums`, output regression) will skip without a token. Make the repo public, or accept the skips.
- [ ] **Model card has placeholders.** License is `TBA` (front matter carries `cc-by-nc-sa-4.0` copied from the sibling purely to satisfy Hub validation — it is **not** a confirmed license). Training data, hyperparameters, evaluation, compute, and citation are all `TBA`. This is an ablation checkpoint with no benchmark numbers; the card says so explicitly.

## Verification performed

- `strict=True` load of the source backbone: 252/252, zero missing, zero unexpected
- `load_model` via local path, `gs://` (`.pt` and `.safetensors`), `hf://`, and registry name — all 252/252 and bitwise identical to the source
- `convert_to_safetensors.py --verify full`: 252 tensors match
- `assert_safetensors_has_weights`: passes
- Offline table validation: all three fingerprint profiles and the checksum table match the official HF model set exactly

The full pytest suite was **not** run locally.